### PR TITLE
DM-15216: Add nbreport login command

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,16 @@
 Change log
 ##########
 
+0.5.0 (2018-07-27)
+==================
+
+- New ``nbreport login`` command that generates a GitHub personal access token on behalf of the user and caches it in a ``~/.nbreport.yaml`` file.
+  LSST's notebook-based report system uses GitHub to authenticate users submitting reports and to authorize the publication based on GitHub organization memberships.
+
+- New dependencies on ``requests`` and ``responses``.
+
+`DM-15216 <https://jira.lsstcorp.org/browse/DM-15216>`__.
+
 0.4.0 (2018-07-25)
 ==================
 

--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ You can use nbreport to:
 
 Try this test command to get a sense for how nbreport work::
 
-   nbreport test https://github.com/lsst-sqre --git-subdir tests/TESTR-000 -c title My first report
+   nbreport test https://github.com/lsst-sqre/nbreport --git-subdir tests/TESTR-000 -c title "My first report"
 
 This test command uses the `TESTR-000 example report repository`_ in this project's own Git repository.
 Next, it creates a new instance called ``TESTR-000-test`` in your current working directory and configures the notebook so that the ``title`` variable is ``"My first report"``.

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -6,7 +6,7 @@ Installation for development
 ============================
 
 Create a virtual environment for development.
-Then install LTD Conveyor with development dependencies:
+Then install nbreport with development dependencies:
 
 .. code-block:: bash
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,7 +24,7 @@ This one-line command creates a test report instance:
 
 .. code-block:: bash
 
-   nbreport test https://github.com/lsst-sqre --git-subdir tests/TESTR-000 -c title My first report
+   nbreport test https://github.com/lsst-sqre/nbreport --git-subdir tests/TESTR-000 -c title "My first report"
 
 This test command uses the `TESTR-000 example report repository`_ in this project's own Git repository.
 Next, it creates a new report instance called ``TESTR-000-test`` in your current working directory and configures the notebook so that the ``title`` variable is ``"My first report"``.

--- a/nbreport/cli/login.py
+++ b/nbreport/cli/login.py
@@ -4,7 +4,12 @@ personal access token on behalf of a user.
 
 __all__ = ('login',)
 
+import datetime
+from getpass import getuser
+from socket import gethostname
+
 import click
+import requests
 
 
 @click.command()
@@ -36,3 +41,83 @@ def login(ctx, github_username, github_password):
     https://github.com/settings/tokens.
     """
     click.echo('Getting a personal access token from GitHub.')
+
+    try:
+        token_data = request_github_token(
+            github_username, github_password, twofactor=None)
+    except GitHubTwoFactorRequired:
+        twofactor = click.prompt('Your GitHub two-factor auth code', type=str)
+        token_data = request_github_token(
+            github_username, github_password, twofactor=twofactor)
+
+    click.echo('token: %s' % token_data['token'])
+
+
+def request_github_token(github_username, github_password, twofactor=None):
+    """Request a new GitHub personal access token on behalf of a user.
+
+    Parameters
+    ----------
+    github_username : `str`
+        User's GitHub username.
+    github_password : `str`
+        User's GitHub password.
+    twofactor : `str`, optional
+        The current two-factor code.
+
+    Returns
+    -------
+    `dict`
+        JSON body of the GitHub `POST /authorizations
+        <https://developer.github.com/v3/oauth_authorizations/#create-a-new-authorization>`_
+        endpoint. The token itself is in ``'token'`` key.
+
+    Raises
+    ------
+    GitHubTwoFactorRequired
+        Raised if a ``twofactor`` argument is required, but not given.
+
+    Notes
+    -----
+    The token is generated with the ``read:user`` scope.
+
+    The token is generated with a note formatted as::
+
+        nbreport for {{user}}@{{hostname}} on {{ISO8601}}
+
+    The token can be revoked at https://github.com/settings/tokens.
+    """
+    note = 'nbreport for {user}@{machine} on {time}'.format(
+        user=getuser(),
+        machine=gethostname(),
+        time=datetime.datetime.now().isoformat()
+    )
+    request_data = {
+        'scopes': ['read:user'],
+        'note': note,
+        'note_url': 'https://nbreport.lsst.io'
+    }
+    headers = {
+        'Accept': 'application/vnd.github.v3+json'
+    }
+    if twofactor is not None:
+        headers['X-GitHub-OTP'] = str(twofactor)
+    response = requests.post(
+        'https://api.github.com/authorizations',
+        auth=(github_username, github_password),
+        headers=headers,
+        json=request_data
+    )
+
+    # Handle two-factor authentication
+    if response.status_code == 401 and 'X-GitHub-OTP' in response.headers:
+        raise GitHubTwoFactorRequired
+    # Handle other errors
+    response.raise_for_status()
+
+    return response.json()
+
+
+class GitHubTwoFactorRequired(Exception):
+    """Two-factor authentication is required for this GitHub request.
+    """

--- a/nbreport/cli/login.py
+++ b/nbreport/cli/login.py
@@ -1,0 +1,38 @@
+"""Implementation for the nbreport login command, which obtains a GitHub
+personal access token on behalf of a user.
+"""
+
+__all__ = ('login',)
+
+import click
+
+
+@click.command()
+@click.option(
+    '--name', 'github_username', prompt='Your GitHub username',
+    help='Your GitHub username. You’ll be prompted for it if not provided '
+         'as an option.'
+)
+@click.password_option(
+    '--password', 'github_password', prompt='Your GitHub password',
+    help='Your GitHub username. You’ll be prompted for it if not provided '
+         'as an option.'
+)
+@click.pass_context
+def login(ctx, github_username, github_password):
+    """Obtain a personal access token from GitHub.
+
+    Other nbreport subcommands that publish report instances authenticate
+    using your GitHub identity and organization memberships. Run this command
+    first to obtain a personal access token that you can use to authenticate
+    with the other commands.
+
+    This command creates a personal access token that is stored in the
+    ``~/.nbreport.yaml`` file.
+
+    By using a personal access token, nbreport ensures that your GitHub
+    password never passes through LSST's servers.  You can always revoke a
+    personal access token created by this command by going to
+    https://github.com/settings/tokens.
+    """
+    click.echo('Getting a personal access token from GitHub.')

--- a/nbreport/cli/main.py
+++ b/nbreport/cli/main.py
@@ -7,6 +7,7 @@ import logging
 
 import click
 
+from .login import login
 from .test import test
 
 
@@ -62,4 +63,5 @@ def help(ctx, topic, **kw):
 
 
 # Add subcommands from other modules
+main.add_command(login)
 main.add_command(test)

--- a/nbreport/cli/test.py
+++ b/nbreport/cli/test.py
@@ -82,8 +82,8 @@ def test(ctx, repo_path_or_url, template_variables, instance_path, instance_id,
 
     .. code-block:: bash
 
-        nbreport test https://github.com/lsst-sqre \
-          --git-subdir tests/TESTR-000 -c title My first report
+        nbreport test https://github.com/lsst-sqre/nbreport \
+          --git-subdir tests/TESTR-000 -c title "My first report"
 
     **Required arguments**
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,8 @@ install_requires = [
     'nbconvert',
     'jupyter',  # needed by nbconvert
     'ruamel.yaml>=0.15.0,<0.16.0',
-    'GitPython'
+    'GitPython',
+    'requests>=2.0',
 ]
 
 # Setup dependencies
@@ -49,6 +50,7 @@ tests_require = [
     'pytest==3.5.0',
     'pytest-cov==2.5.1',
     'pytest-flake8==1.0.0',
+    'responses==0.9.0',
 ]
 
 # Optional/development dependencies

--- a/tests/test_cli_login.py
+++ b/tests/test_cli_login.py
@@ -1,10 +1,13 @@
 """Test the nbreport login command.
 """
 
+from pathlib import Path
+
 import pytest
 import responses
 
 from nbreport.cli.login import request_github_token, GitHubTwoFactorRequired
+from nbreport.cli.login import write_token
 
 
 @responses.activate
@@ -60,3 +63,33 @@ def test_request_github_token_with_2fa():
         == 'https://api.github.com/authorizations'
     assert data['token'] == 'mytoken'
     assert data['note'] == 'note for token'
+
+
+def test_write_token(tmpdir):
+    """Test writing and re-writing .nbreport.yaml with github auth info.
+    """
+    username = 'exampleuser'
+    token = 'example'
+    note = 'note example'
+    path = Path(tmpdir) / '.nbreport.yaml'
+
+    write_token(username, token, note, path=path)
+
+    with open(path) as fp:
+        config_text = fp.read()
+    assert config_text == (
+        'github:\n'
+        '  username: exampleuser\n'
+        '  token: example  # note example\n'
+    )
+
+    # Now re-write the token to ensure we can re-write one
+    write_token(username, 'newtoken', note, path=path)
+
+    with open(path) as fp:
+        config_text = fp.read()
+    assert config_text == (
+        'github:\n'
+        '  username: exampleuser\n'
+        '  token: newtoken  # note example\n'
+    )

--- a/tests/test_cli_login.py
+++ b/tests/test_cli_login.py
@@ -1,0 +1,62 @@
+"""Test the nbreport login command.
+"""
+
+import pytest
+import responses
+
+from nbreport.cli.login import request_github_token, GitHubTwoFactorRequired
+
+
+@responses.activate
+def test_request_github_token():
+    """Test getting a token for a user that doesn't use 2FA.
+    """
+    responses.add(
+        responses.POST,
+        'https://api.github.com/authorizations',
+        json={'token': 'mytoken',
+              'note': 'note for token'},
+        status=201)
+
+    data = request_github_token('user', 'password')
+
+    assert len(responses.calls) == 1
+    assert data['token'] == 'mytoken'
+    assert data['note'] == 'note for token'
+    assert responses.calls[0].request.url \
+        == 'https://api.github.com/authorizations'
+
+
+@responses.activate
+def test_request_github_token_needs_2fa():
+    """Test that a login requiring 2FA is identified.
+    """
+    responses.add(
+        responses.POST,
+        'https://api.github.com/authorizations',
+        status=401,
+        headers={'X-GitHub-OTP': 'required; :2fa-app'})
+
+    with pytest.raises(GitHubTwoFactorRequired):
+        request_github_token('user', 'password')
+
+
+@responses.activate
+def test_request_github_token_with_2fa():
+    """Test request_github_token when providing a one-time password.
+    """
+    responses.add(
+        responses.POST,
+        'https://api.github.com/authorizations',
+        json={'token': 'mytoken',
+              'note': 'note for token'},
+        status=201)
+
+    data = request_github_token('user', 'password', twofactor='123456')
+
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.headers['X-GitHub-OTP'] == '123456'
+    assert responses.calls[0].request.url \
+        == 'https://api.github.com/authorizations'
+    assert data['token'] == 'mytoken'
+    assert data['note'] == 'note for token'


### PR DESCRIPTION
This command obtains a personal access token from GitHub on behalf of a user and persists it in a `~/.nbreport.yaml` configuration file. We'll be using GitHub for authentication with the `api.lsst.codes/nbreport` service and for authorization based on GitHub organization memberships.