### PR TITLE
DM-15199: Add read:org scope to personal token

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,15 @@
 Change log
 ##########
 
+0.5.1 (2018-08-03)
+==================
+
+- Add ``read:org`` role to the personal access token obtained by ``nbreport login``.
+  This role is necessary for the api.lsst.codes/nbreport service to _authorize_ a user based on their GitHub organization memberships.
+  The list of token roles is now ``read:org`` and ``read:user``.
+
+`DM-15199 <https://jira.lsstcorp.org/browse/DM-15199>`__.
+
 0.5.0 (2018-07-27)
 ==================
 

--- a/nbreport/cli/login.py
+++ b/nbreport/cli/login.py
@@ -58,8 +58,8 @@ def login(ctx, github_username, github_password):
         token_data['token'],
         token_data['note'])
     click.echo(
-        'Saved the user:read token to ~/.nbreport.yaml. You '
-        'can revoke it at https://github.com/settings/tokens'
+        'Saved the token to ~/.nbreport.yaml. It has read:user and read:org '
+        'scope. You can revoke it at https://github.com/settings/tokens'
     )
 
 
@@ -89,7 +89,7 @@ def request_github_token(github_username, github_password, twofactor=None):
 
     Notes
     -----
-    The token is generated with the ``read:user`` scope.
+    The token is generated with the ``read:user`` and ``read:org`` scopes.
 
     The token is generated with a note formatted as::
 
@@ -103,7 +103,7 @@ def request_github_token(github_username, github_password, twofactor=None):
         time=datetime.datetime.now().isoformat()
     )
     request_data = {
-        'scopes': ['read:user'],
+        'scopes': ['read:user', 'read:org'],
         'note': note,
         'note_url': 'https://nbreport.lsst.io'
     }

--- a/tests/test_cli_login.py
+++ b/tests/test_cli_login.py
@@ -28,6 +28,8 @@ def test_request_github_token():
     assert data['note'] == 'note for token'
     assert responses.calls[0].request.url \
         == 'https://api.github.com/authorizations'
+    assert b'read:user' in responses.calls[0].request.body
+    assert b'read:org' in responses.calls[0].request.body
 
 
 @responses.activate


### PR DESCRIPTION
The organization lookup that's done server-side also needs the `read:org` scope, in addition to `read:user`.