### PR TITLE
DM-15253: Implement commands for fully-featured use

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,34 @@
 Change log
 ##########
 
+0.6.0 (2018-08-08)
+==================
+
+- Several new commands were added that make the ``nbreport`` command line client fully functional:
+
+  - ``nbreport register`` command registers a report repo with LSST the Docs so that instances can be published.
+
+  - ``nbreport init`` command initializes a new report instance (by reserving a number with the API server and optionally rendering template variables).
+
+  - ``nbreport compute`` command computes a report instance's notebook.
+
+  - ``nbreport upload`` command uploads a report instance to the API server, which publishes it to LSST the Docs.
+
+  - ``nbreport issue`` command performs the equivalent of ``init``, ``compute``, and ``upload`` in a single step.
+
+- Key metadata from each instance ``nbreport.yaml`` file is not available as a Jinja template variable, namely: ``handle``, ``title``, ``git_repo``, ``git_repo_subdir``, ``instance_id``, ``instance_handle``.
+  These variables aren't part of the ``cookiecutter`` namespace and can't be overridden on the command line.
+
+- Metadata from ``nbreport.yaml``, as well as the final set of ``cookiecutter`` template variables, are included in the notebook files's metadata.
+  This provides a record of how the notebook was constructed, and will be used on the server to both render the notebook page and to provide filtering of notebooks.
+
+- Refactored code related to reading ``~/.nbreport.yaml`` out of the ``nbreport login`` command and into the ``nbreport.userconfig`` module.
+  The main command reads this file and passes data like the authentication token to subcommands.
+
+- Refactored ``create_instance()`` out of the ``nbreport test`` command and into ``nbreport.processing`` so that multiple subcommands (``init``, ``issue``) can consume it.
+
+`DM-15253 <https://jira.lsstcorp.org/browse/DM-15253>`__.
+
 0.5.1 (2018-08-03)
 ==================
 

--- a/docs/api-reference.rst
+++ b/docs/api-reference.rst
@@ -44,3 +44,15 @@ nbreport treats each cell's source as a Jinja template.
    :no-main-docstr:
    :no-heading:
    :no-inheritance-diagram:
+
+.. _nbreport.userconfig:
+
+nbreport.userconfig
+===================
+
+The ``nbreport.userconfig`` module provides interfaces to the ``~/.nbreport.yaml`` file, which is used to store GitHub credentials.
+
+.. automodapi:: nbreport.userconfig
+   :no-main-docstr:
+   :no-heading:
+   :no-inheritance-diagram:

--- a/docs/api-reference.rst
+++ b/docs/api-reference.rst
@@ -16,6 +16,18 @@ The ``nbreport.compute`` module supports running Jupyter notebooks to compute ou
    :no-heading:
    :no-inheritance-diagram:
 
+.. _nbreport.processing:
+
+nbreport.processing
+===================
+
+The ``nbreport.processing`` module provides internal helpers for the command line apps.
+
+.. automodapi:: nbreport.processing
+   :no-main-docstr:
+   :no-heading:
+   :no-inheritance-diagram:
+
 .. _nbreport.repo:
 
 nbreport.repo
@@ -27,7 +39,6 @@ The ``nbreport.repo`` module provides APIs for managing report repositories.
    :no-main-docstr:
    :no-heading:
    :no-inheritance-diagram:
-   :skip: ReportConfig
 
 .. _nbreport.templating:
 

--- a/nbreport/cli/compute.py
+++ b/nbreport/cli/compute.py
@@ -1,0 +1,39 @@
+"""Implementation for the ``nbreport compute`` command.
+"""
+
+__all__ = ('compute',)
+
+import click
+
+from ..compute import compute_notebook_file
+from ..instance import ReportInstance
+
+
+@click.command()
+@click.argument(
+    'instance_path', default=None, required=True, nargs=1,
+    type=click.Path(exists=True, file_okay=False, dir_okay=True)
+)
+@click.option(
+    '--timeout', type=int, default=None,
+    help='Timeout for computing individual notebook cells. Default is no '
+         'timeout.'
+)
+@click.option(
+    '-k', '--kernel', type=str, default='',
+    help='Name of the Jupyter kernel to use for computing the notebook. '
+         'The default Python kernel is used if this option is not set.'
+)
+@click.pass_context
+def compute(ctx, instance_path, timeout, kernel):
+    """Compute the notebook in a report instance.
+
+    **Required arguments**
+
+    ``INSTANCE_PATH``
+        The path to the report repository directory. You can create an
+        instance with the ``nbreport init`` command.
+    """
+    instance = ReportInstance(instance_path)
+    compute_notebook_file(instance.ipynb_path, timeout=timeout,
+                          kernel_name=kernel)

--- a/nbreport/cli/init.py
+++ b/nbreport/cli/init.py
@@ -1,0 +1,106 @@
+"""Implementation of the ``nbreport init`` command that initializes a new
+report instance.
+"""
+
+__all__ = ('init',)
+
+from tempfile import TemporaryDirectory
+
+import click
+
+from ..repo import ReportRepo
+from ..processing import is_url, create_instance
+
+
+@click.command()
+@click.argument(
+    'repo_path_or_url', default=None, required=True, nargs=1,
+)
+@click.option(
+    '-c', '--config', 'template_variables', nargs=2, type=str, multiple=True,
+    help='Template key-value pairs. For example, if the report has a template '
+         'variable called ``title``, you can provide it as ``-c title "Hello '
+         'World!"``. You can provide multiple -c/--config options. If no '
+         'variables are set, the notebook’s templated cells are not rendered. '
+         'You can render the cells laster with the ``nbreport render`` '
+         'command.'
+)
+@click.option(
+    '-d', '--dir', 'instance_path', type=click.Path(),
+    help='Path of the report directory. By default, the report directory '
+         'is created in the current working directory and is named '
+         '{{handle}}-{{id}}.'
+)
+@click.option(
+    '--git-subdir', 'git_repo_subdir', type=str, default=None,
+    help='If cloning from a Git repository and the report is not at the root '
+         'of that Git repository, set Git repo-relative path to the report '
+         'with this option.'
+)
+@click.option(
+    '--git-ref', 'git_repo_ref', type=str, default='master',
+    help='If cloning from a Git repository, check out a specific Git ref '
+         '(branch or tag name).'
+)
+@click.option(
+    '--overwrite/--no-overwrite', default=False,
+    help='Whether or not to overwrite an instance (on disk). Overwriting '
+         'is disable by default. If --dir is not set, overwriting should '
+         'not be necessary.'
+)
+@click.pass_context
+def init(ctx, repo_path_or_url, template_variables, instance_path,
+         git_repo_subdir, git_repo_ref, overwrite):
+    """Initialize a new report instance.
+
+    This command creates a report **instance** from a report **repository**.
+    It can work with either local report repositories, or even clone a
+    report repository (from GitHub, for example).
+
+    This command contacts the nbreport server to reserve a unique **instance
+    ID**.
+
+    You can also render the report's template variables by providing
+    ``-c`` / ``--config`` options. If you don't render the template variables
+    now, you can do it later with the ``nbreport render`` command.
+
+    **Required arguments**
+
+    ``REPO_PATH_OR_URL``
+        The path to the report repository directory on the file system **or**
+        the URL of a remote Git repository.
+    """
+    template_variables = dict(template_variables)
+    if len(template_variables) == 0:
+        # If no variables were configured by the user, defer rendering the
+        # cell templates to the nbreport render command
+        template_variables = None
+
+    create_instance_args = {
+        'template_variables': template_variables,
+        'instance_path': instance_path,
+        'github_username': ctx.obj['config']['github']['username'],
+        'github_token': ctx.obj['config']['github']['token'],
+        'server': ctx.obj['server'],
+        'overwrite': overwrite,
+    }
+
+    if is_url(repo_path_or_url):
+        with TemporaryDirectory() as tempdir:
+            report_repo = ReportRepo.git_clone(
+                repo_path_or_url,
+                clone_base_dir=tempdir,
+                subdir=git_repo_subdir,
+                checkout=git_repo_ref
+            )
+        instance = create_instance(report_repo, **create_instance_args)
+    else:
+        report_repo = ReportRepo(repo_path_or_url)
+        instance = create_instance(report_repo, **create_instance_args)
+
+    click.echo('Created new report instance at {0!s}'.format(instance.dirname))
+
+    if template_variables is None:
+        click.echo(
+            'Run nbreport render {0!s} (with -c options) to render '
+            'the instance’s templated cells.'.format(instance.dirname))

--- a/nbreport/cli/issue.py
+++ b/nbreport/cli/issue.py
@@ -1,0 +1,98 @@
+"""Implementation of the ``nbreport issue`` command.
+"""
+
+__all__ = ('issue',)
+
+from tempfile import TemporaryDirectory
+
+import click
+
+from nbreport.compute import compute_notebook_file
+from nbreport.processing import create_instance, is_url
+from nbreport.repo import ReportRepo
+
+
+@click.command()
+@click.argument(
+    'repo_path_or_url', default=None, required=True, nargs=1,
+)
+@click.option(
+    '-c', '--config', 'template_variables', nargs=2, type=str, multiple=True,
+    help='Template key-value pairs. For example, if the report has a template '
+         'variable called ``title``, you can provide it as ``-c title "Hello '
+         'World!"``. You can provide multiple -c/--config options.'
+)
+@click.option(
+    '-d', '--dir', 'instance_path', type=click.Path(),
+    help='Path of the report directory. By default, the report directory '
+         'is created in the current working directory and is named '
+         '{{handle}}-{{id}}.'
+)
+@click.option(
+    '--timeout', type=int, default=None,
+    help='Timeout for computing individual notebook cells. Default is no '
+         'timeout.'
+)
+@click.option(
+    '-k', '--kernel', type=str, default='',
+    help='Name of the Jupyter kernel to use for computing the notebook. '
+         'The default Python kernel is used if this option is not set.'
+)
+@click.option(
+    '--git-subdir', 'git_repo_subdir', type=str, default=None,
+    help='If cloning from a Git repository and the report is not at the root '
+         'of that Git repository, set Git repo-relative path to the report '
+         'with this option.'
+)
+@click.option(
+    '--git-ref', 'git_repo_ref', type=str, default='master',
+    help='If cloning from a Git repository, check out a specific Git ref '
+         '(branch or tag name).'
+)
+@click.pass_context
+def issue(ctx, repo_path_or_url, template_variables, instance_path, timeout,
+          kernel, git_repo_subdir, git_repo_ref):
+    """Create, compute, and upload a report instance, all-in-one.
+
+    **Required arguments**
+
+    ``REPO_PATH_OR_URL``
+        The path to the report repository directory on the file system **or**
+        the URL of a remote Git repository.
+    """
+    template_variables = dict(template_variables)
+
+    create_instance_args = {
+        'template_variables': template_variables,
+        'instance_path': instance_path,
+        'github_username': ctx.obj['config']['github']['username'],
+        'github_token': ctx.obj['config']['github']['token'],
+        'server': ctx.obj['server'],
+        'overwrite': False,
+    }
+
+    if is_url(repo_path_or_url):
+        with TemporaryDirectory() as tempdir:
+            report_repo = ReportRepo.git_clone(
+                repo_path_or_url,
+                clone_base_dir=tempdir,
+                subdir=git_repo_subdir,
+                checkout=git_repo_ref
+            )
+            instance = create_instance(report_repo, **create_instance_args)
+    else:
+        report_repo = ReportRepo(repo_path_or_url)
+        instance = create_instance(report_repo, **create_instance_args)
+
+    compute_notebook_file(instance.ipynb_path, timeout=timeout,
+                          kernel_name=kernel)
+
+    instance.upload(
+        github_username=ctx.obj['config']['github']['username'],
+        github_token=ctx.obj['config']['github']['token'],
+        server=ctx.obj['server'])
+
+    click.echo('Issued report instance {}.'.format(
+        instance.config['instance_handle']))
+    click.echo('Report is being published to {}'.format(
+        instance.config['published_instance_url']))

--- a/nbreport/cli/login.py
+++ b/nbreport/cli/login.py
@@ -11,8 +11,7 @@ from socket import gethostname
 import click
 import requests
 
-from ..userconfig import (read_config, create_empty_config,
-                          insert_github_config, write_config)
+from ..userconfig import insert_github_config, write_config
 
 
 @click.command()
@@ -53,10 +52,13 @@ def login(ctx, github_username, github_password):
         token_data = request_github_token(
             github_username, github_password, twofactor=twofactor)
 
-    write_token(
+    config = insert_github_config(
+        ctx.obj['config'],
         github_username,
         token_data['token'],
-        token_data['note'])
+        token_note=token_data['note'])
+    write_config(config, path=ctx.obj['config_path'])
+
     click.echo(
         'Saved the token to ~/.nbreport.yaml. It has read:user and read:org '
         'scope. You can revoke it at https://github.com/settings/tokens'
@@ -131,29 +133,3 @@ def request_github_token(github_username, github_password, twofactor=None):
 class GitHubTwoFactorRequired(Exception):
     """Two-factor authentication is required for this GitHub request.
     """
-
-
-def write_token(username, token, note, path=None):
-    """Write a GitHub personal access token to the user's nbreport
-    configuration file.
-
-    Parameters
-    ----------
-    username : `str`
-        GitHub username.
-    token : `str`
-        GitHub personal access token belonging to the user.
-    note : `str`
-        Note to associate with the token.
-    path : `str`, optional
-        Path to the nbreport configuration file. By default this is located
-        at ``~/.nbreport.yaml``.
-    """
-    try:
-        config = read_config(path=path)
-    except FileNotFoundError:
-        config = create_empty_config()
-
-    config = insert_github_config(config, username, token, token_note=note)
-
-    write_config(config, path=path)

--- a/nbreport/cli/main.py
+++ b/nbreport/cli/main.py
@@ -31,9 +31,13 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
     help='Path to the nbreport user configuration file. '
          'Default: ``~/.nbreport.yaml``.'
 )
+@click.option(
+    '--server', default='https://api.lsst.codes',
+    help='URL of the API host server. Default: ``https://api.lsst.codes``.'
+)
 @click.version_option(message='%(version)s')
 @click.pass_context
-def main(ctx, log_level, config_path):
+def main(ctx, log_level, config_path, server):
     """nbreport is a command-line client for LSST's notebook-based report
     system. Use nbreport to initialize, compute, and upload report instances.
     """
@@ -61,7 +65,8 @@ def main(ctx, log_level, config_path):
     # ctx.obj object as the first argument.
     ctx.obj = {
         'config_path': config_path,
-        'config': config
+        'config': config,
+        'server': server
     }
 
 

--- a/nbreport/cli/main.py
+++ b/nbreport/cli/main.py
@@ -11,6 +11,7 @@ import click
 from ..userconfig import read_config, get_config_path, create_empty_config
 from .login import login
 from .register import register
+from .init import init
 from .test import test
 
 
@@ -88,4 +89,5 @@ def help(ctx, topic, **kw):
 # Add subcommands from other modules
 main.add_command(login)
 main.add_command(register)
+main.add_command(init)
 main.add_command(test)

--- a/nbreport/cli/main.py
+++ b/nbreport/cli/main.py
@@ -13,6 +13,7 @@ from .compute import compute
 from .login import login
 from .register import register
 from .init import init
+from .issue import issue
 from .test import test
 from .upload import upload
 
@@ -94,4 +95,5 @@ main.add_command(register)
 main.add_command(init)
 main.add_command(compute)
 main.add_command(upload)
+main.add_command(issue)
 main.add_command(test)

--- a/nbreport/cli/main.py
+++ b/nbreport/cli/main.py
@@ -14,6 +14,7 @@ from .login import login
 from .register import register
 from .init import init
 from .test import test
+from .upload import upload
 
 
 # Add -h as a help shortcut option
@@ -92,4 +93,5 @@ main.add_command(login)
 main.add_command(register)
 main.add_command(init)
 main.add_command(compute)
+main.add_command(upload)
 main.add_command(test)

--- a/nbreport/cli/main.py
+++ b/nbreport/cli/main.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import click
 
 from ..userconfig import read_config, get_config_path, create_empty_config
+from .compute import compute
 from .login import login
 from .register import register
 from .init import init
@@ -90,4 +91,5 @@ def help(ctx, topic, **kw):
 main.add_command(login)
 main.add_command(register)
 main.add_command(init)
+main.add_command(compute)
 main.add_command(test)

--- a/nbreport/cli/main.py
+++ b/nbreport/cli/main.py
@@ -10,6 +10,7 @@ import click
 
 from ..userconfig import read_config, get_config_path, create_empty_config
 from .login import login
+from .register import register
 from .test import test
 
 
@@ -86,4 +87,5 @@ def help(ctx, topic, **kw):
 
 # Add subcommands from other modules
 main.add_command(login)
+main.add_command(register)
 main.add_command(test)

--- a/nbreport/cli/register.py
+++ b/nbreport/cli/register.py
@@ -1,0 +1,74 @@
+"""Implementation of the ``nbreport register`` command that registers a new
+report with LSST the Docs.
+"""
+
+__all__ = ('register',)
+
+from urllib.parse import urljoin
+
+import click
+import requests
+
+from ..repo import ReportRepo
+
+
+@click.command()
+@click.argument(
+    'repo_path', default=None, required=True, nargs=1,
+)
+@click.pass_context
+def register(ctx, repo_path):
+    """Register a report with LSST the Docs.
+
+    This command only needs to be run once, when you're creating a new report
+    repository. The command creates a new "product" on LSST the Docs where
+    instances of the report are published.
+
+    **Required arguments**
+
+    ``REPO_PATH``
+        Path to the report repository. The report repository must be a local
+        directory (not a remote Git repository) because the repository's
+        nbreport.yaml metadata file will be modified. The new metadata created
+        by this command must be committed into the report repository.
+    """
+    report_repo = ReportRepo(repo_path)
+
+    handle = report_repo.config['handle']
+    title = report_repo.config['title']
+    git_repo = report_repo.config['git_repo']
+
+    try:
+        github_username = ctx.obj['config']['github']['username']
+        github_token = ctx.obj['config']['github']['token']
+    except KeyError:
+        raise click.UsageError(
+            'Could not find GitHub authentication data in {0!s}. Try '
+            'running "nbreport login" first.'.format(ctx.obj['config_path'])
+        )
+
+    # Allow for user confirmation
+    click.echo('Registering report with this metadata from nbreport.yaml:')
+    click.echo('\tHandle: {}'.format(handle))
+    click.echo('\tTitle: {}'.format(title))
+    click.echo('\tGit repository: {}'.format(git_repo))
+    click.confirm('Register this report?', abort=True)
+
+    response = requests.post(
+        urljoin(ctx.obj['server'], '/nbreport/reports/'),
+        auth=(github_username, github_token),
+        json={
+            'handle': handle,
+            'title': title,
+            'git_repo': git_repo
+        }
+    )
+    response.raise_for_status()
+    response_data = response.json()
+
+    report_repo.config['ltd_product'] = response_data['product']
+    report_repo.config['published_url'] = response_data['published_url']
+    report_repo.config['ltd_url'] = response_data['product_url']
+
+    click.echo('Registered report at {}'.format(
+        report_repo.config['published_url']))

--- a/nbreport/cli/test.py
+++ b/nbreport/cli/test.py
@@ -6,13 +6,13 @@ __all__ = ('test',)
 import logging
 import pathlib
 from tempfile import TemporaryDirectory
-from urllib.parse import urlparse
 
 import click
 
 from ..compute import compute_notebook_file
 from ..repo import ReportRepo
 from ..instance import ReportInstance
+from ..processing import is_url
 
 
 @click.command()
@@ -129,13 +129,3 @@ def _run(report_repo, instance_path, instance_id, template_variables,
     compute_notebook_file(instance.ipynb_path, timeout=timeout,
                           kernel_name=kernel)
     logger.debug('Computed notebook %s', instance.ipynb_path)
-
-
-def is_url(path_or_url):
-    """Test if the token represents a URL or a local path.
-    """
-    parts = urlparse(path_or_url)
-    if parts.scheme is not '':
-        return True
-    else:
-        return False

--- a/nbreport/cli/upload.py
+++ b/nbreport/cli/upload.py
@@ -1,0 +1,35 @@
+"""Implementation for the ``nbreport upload`` command.
+"""
+
+__all__ = ('upload',)
+
+import click
+
+from nbreport.instance import ReportInstance
+
+
+@click.command()
+@click.argument(
+    'instance_path', default=None, required=True, nargs=1,
+    type=click.Path(exists=True, file_okay=False, dir_okay=True)
+)
+@click.pass_context
+def upload(ctx, instance_path):
+    """Upload and publish a report instance.
+
+    **Required arguments**
+
+    ``INSTANCE_PATH``
+        The path to the report repository directory. You can create an
+        instance with the ``nbreport init`` command. The report repository
+        must already be computed with the ``nbreport compute`` command.
+    """
+    instance = ReportInstance(instance_path)
+    instance.upload(
+        github_username=ctx.obj['config']['github']['username'],
+        github_token=ctx.obj['config']['github']['token'],
+        server=ctx.obj['server'])
+
+    click.echo('Upload complete.')
+    click.echo('Report is being published to {}'.format(
+        instance.config['published_instance_url']))

--- a/nbreport/instance.py
+++ b/nbreport/instance.py
@@ -163,7 +163,13 @@ class ReportInstance:
             context_path=self.context_path,
             extra_context=context)
 
+        # Add context to the config
+        self.config.update({'context': context})
+
         notebook = render_notebook(notebook, context, jinja_env)
+
+        # Add config to the notebook metadata
+        notebook.metadata.update({'nbreport': dict(self.config)})
 
         nbformat.write(notebook, str(self.ipynb_path))
 

--- a/nbreport/instance.py
+++ b/nbreport/instance.py
@@ -96,7 +96,9 @@ class ReportInstance:
         context : `dict`, optional
             Key-value pairs that override the default template context in
             the context file (``cookiecutter.json`,
-            `ReportInstance.context_path`).
+            `ReportInstance.context_path`). If `None` the notebook *is not*
+            rendered. If an empty dict, ``{}``, then the notebook is rendered
+            entirely with the default context.
         overwrite : `bool`, optional
             If `True`, an existing report instance directory will be deleted
             and replaced by the new report instance directory. Default is
@@ -133,11 +135,12 @@ class ReportInstance:
         instance.config['instance_handle'] = '{handle}-{instance_id}'.format(
             **instance.config)
 
-        instance._render(context=context)
+        if context is not None:
+            instance.render(context=context)
 
         return instance
 
-    def _render(self, context=None):
+    def render(self, context=None):
         """Render the notebook from the template in the notebook
 
         Parameters

--- a/nbreport/processing.py
+++ b/nbreport/processing.py
@@ -1,10 +1,16 @@
 """High-level functions that carry out work for the CLI subcommands.
 """
 
-__all__ = ('is_url',)
+__all__ = ('is_url', 'create_instance')
 
+import logging
+import pathlib
+from urllib.parse import urlparse, urljoin
 
-from urllib.parse import urlparse
+import click
+import requests
+
+from .instance import ReportInstance
 
 
 def is_url(path_or_url):
@@ -25,3 +31,98 @@ def is_url(path_or_url):
         return True
     else:
         return False
+
+
+def create_instance(report_repo, instance_id=None, template_variables=None,
+                    instance_path=None, overwrite=False,
+                    github_username=None, github_token=None, server=None):
+    """Create a report instance.
+
+    Parameters
+    ----------
+    report_repo : `nbreport.repo.ReportRepo`
+        Report repository.
+    instance_id : `str`, optional
+        The instance identifier. Leave as `None` to reserve a new instance
+        with the server.
+    template_variables : `dict`, optional
+        If provided, these key-value pairs are used to render the templated
+        notebook.
+    instance_path : `str` or `pathlib.Path`, optional
+        If provided, this is the directory of the report instance. Otherwise,
+        a directory will be automatically created in the current working
+        directory, formatted as ``{{handle}}-{{id}}``.
+    overwrite : `bool`, optional
+        If `True`, and a directory of the same name as ``instance_path``
+        exists, that directory is overwritten with the new instance.
+    github_username : `str`, optional
+        GitHub username. Only required if ``instance_id`` is None.
+    github_token : `str`, optional
+        Personal access token for the GitHub user. Only required if
+        ``instance_id`` is None.
+    server : `str`, optional
+        Hostname of the api.lsst.codes, or equivalent, service. Only required
+        if ``instance_id`` is None.
+
+    Returns
+    -------
+    instance : `nbreport.instance.ReportInstance`
+        A `~nbreport.instance.ReportInstance` corresponding to an instance
+        directory on the local filesystem.
+    """
+    logger = logging.getLogger()
+
+    if instance_id is None:
+        # Register instance with server
+        instance_id = _reserve_instance(report_repo)
+
+    if instance_path is None:
+        instance_path = pathlib.Path(
+            '{0}-{1}'.format(str(report_repo.dirname.name), instance_id))
+    else:
+        instance_path = pathlib.Path(instance_path)
+
+    instance = ReportInstance.from_report_repo(
+        report_repo, instance_path, instance_id, overwrite=overwrite,
+        context=template_variables)
+    logger.debug('Created instance %s at %s', instance, instance_path)
+
+    return instance
+
+
+def _reserve_instance(report_repo, server, github_username, github_token):
+    """Reserve a new instance ID from api.lsst.codes/nbreport.
+
+    This function is only intended to be used by `create_instance`.
+
+    Parameters
+    ----------
+    report_repo : `nbreport.repo.ReportRepo`
+        Report repository.
+    server : `str`
+        Hostname of the api.lsst.codes, or equivalent, service.
+    github_username : `str`
+        GitHub username.
+    github_token : `str`
+        Personal access token for the GitHub user.
+
+    Returns
+    -------
+    instance_id : `str`
+        Instance identifier, which is a string corresponding to an integer.
+    """
+    try:
+        ltd_product = report_repo.config['ltd_product']
+    except KeyError:
+        raise click.UsageError(
+            'Field "ltd_product" not found in the report repository\'s '
+            'nbreport.yaml file. Try registering the report by running '
+            '"nbreport register".')
+
+    url = urljoin(server, '/nbreport/reports/{product}/instances/'.format(
+        product=ltd_product))
+    response = requests.post(url, auth=(github_username, github_token))
+    response.raise_for_status()
+
+    instance_id = response.json()['instance_id']
+    return instance_id

--- a/nbreport/processing.py
+++ b/nbreport/processing.py
@@ -76,7 +76,8 @@ def create_instance(report_repo, instance_id=None, template_variables=None,
 
     if instance_id is None:
         # Register instance with server
-        instance_id = _reserve_instance(report_repo)
+        instance_id = _reserve_instance(report_repo, server, github_username,
+                                        github_token)
 
     if instance_path is None:
         instance_path = pathlib.Path(

--- a/nbreport/processing.py
+++ b/nbreport/processing.py
@@ -47,7 +47,9 @@ def create_instance(report_repo, instance_id=None, template_variables=None,
         with the server.
     template_variables : `dict`, optional
         If provided, these key-value pairs are used to render the templated
-        notebook.
+        notebook. If `None`, the templated notebook *is not* rendered. If
+        an empty `dict`, the templated notebook is renderd but entirely with
+        defaults defined in ``cookiecutter.json``.
     instance_path : `str` or `pathlib.Path`, optional
         If provided, this is the directory of the report instance. Otherwise,
         a directory will be automatically created in the current working

--- a/nbreport/processing.py
+++ b/nbreport/processing.py
@@ -1,0 +1,27 @@
+"""High-level functions that carry out work for the CLI subcommands.
+"""
+
+__all__ = ('is_url',)
+
+
+from urllib.parse import urlparse
+
+
+def is_url(path_or_url):
+    """Test if the token represents a URL or a local path.
+
+    Parameters
+    ----------
+    path_or_url : `str`
+        Token string that can either be a URL or not.
+
+    Returns
+    -------
+    is_url : `bool`
+        Returns `True` is the token is in fact a URL. `False` otherwise.
+    """
+    parts = urlparse(path_or_url)
+    if parts.scheme is not '':
+        return True
+    else:
+        return False

--- a/nbreport/repo.py
+++ b/nbreport/repo.py
@@ -195,6 +195,22 @@ class ReportConfig:
         data[key] = value
         self._write(data)
 
+    def __contains__(self, key):
+        """Test if the configuration contains a key.
+
+        Parameters
+        ----------
+        key : `str`
+            Key.
+
+        Returns
+        -------
+        `bool`
+            `True` if the key is in the configuration. `False` otherwise.
+        """
+        data = self._read()
+        return key in data
+
     def keys(self):
         """Get the sequence of keys at the top-level of the configuration file.
 

--- a/nbreport/templating.py
+++ b/nbreport/templating.py
@@ -76,7 +76,8 @@ def render_cell(cell, context, jinja_env):
 
 
 def load_template_environment(context_path=None,
-                              extra_context=None):
+                              extra_context=None,
+                              system_context=None):
     """Load the context (``cookiecutter.json``) and Jinja template environment.
 
     Parameters
@@ -93,6 +94,12 @@ def load_template_environment(context_path=None,
 
         If ``context_path`` is None, then the context is populated entirely
         from ``extra_context``.
+
+    system_context : `dict`, optional
+        A dictionary of key-value terms that are available to templates, but
+        outside the ``cookiecutter`` context. This argument is used by
+        `nbreport.instance.ReportInstance.render` to pass system metadata
+        from the ``nbreport.yaml`` file into the Jinja context.
 
     Returns
     -------
@@ -126,6 +133,12 @@ def load_template_environment(context_path=None,
         if extra_context is None:
             extra_context = {}
         context = dict(cookiecutter=extra_context)
+
+    if system_context is not None:
+        context.update(system_context)
+
+    print('created context')
+    print(context)
 
     # Also make the Jinja environment
     jinja_env = StrictEnvironment(

--- a/nbreport/userconfig.py
+++ b/nbreport/userconfig.py
@@ -1,0 +1,120 @@
+"""Read and write user configuration (for storing GitHub personal access
+tokens).
+"""
+
+__all__ = ('create_empty_config', 'read_config', 'get_config_path',
+           'write_config', 'insert_github_config')
+
+from pathlib import Path
+
+import ruamel.yaml
+from ruamel.yaml.comments import CommentedMap
+
+
+def create_empty_config():
+    """Create an empty configuration object.
+
+    Returns
+    -------
+    config : ``ruamel.yaml.comments.CommentedMap``
+        The configuration data, as a native ``ruamel.yaml`` map type.
+    """
+    return CommentedMap({'github': None})
+
+
+def read_config(path=None):
+    """Read an existing nbreport YAML-formatted configuration file.
+
+    Parameters
+    ----------
+    path : `str` or `pathlib.Path`, optional
+        An optional, user-provided, override of the default configuration file
+        path. The default path is ``~/.nbreport.yaml``.
+
+    Returns
+    ------
+    config : ``ruamel.yaml.comments.CommentedMap``
+        The configuration data, as a native ``ruamel.yaml`` map type.
+
+    Raises
+    ------
+    FileNotFoundError
+        Raised if the file does not exist.
+    """
+    yaml = ruamel.yaml.YAML()  # round-trip mode
+
+    path = get_config_path(path=path)
+    if not path.exists():
+        raise FileNotFoundError(
+            'Configuration file at {0!s} does not exist'.format(path))
+
+    data = yaml.load(path)
+    return data
+
+
+def write_config(config, path=None):
+    """Write the configuration data to a YAML file
+
+    Parameters
+    ----------
+    config : ``ruamel.yaml.comments.CommentedMap``
+        The configuration data, as a native ``ruamel.yaml`` map type.
+    path : `str` or `pathlib.Path`, optional
+        An optional, user-provided, override of the default configuration file
+        path. The default path is ``~/.nbreport.yaml``.
+    """
+    yaml = ruamel.yaml.YAML()  # round-trip mode
+    path = get_config_path(path=path)
+    yaml.dump(config, path)
+
+
+def get_config_path(path=None):
+    """Get the path to the configuration file.
+
+    By default, this file is ``~/.nbreport.yaml``.
+
+    Parameters
+    ----------
+    path : `str` or `pathlib.Path`, optional
+        An optional, user-provided, override of the default configuration file
+        path.
+
+    Returns
+    -------
+    path : `pathlib.Path`
+        Path to the configuration file (whether it exists, or not).
+    """
+    if path is None:
+        path = Path.home() / '.nbreport.yaml'
+    else:
+        path = Path(path)
+    return path
+
+
+def insert_github_config(config, username, token, token_note=None):
+    """Insert a ``github`` field into the configuration data with GitHub
+    authentication information (username and personal access token).
+
+    Parameters
+    ----------
+    config : ``ruamel.yaml.comments.CommentedMap``
+        The configuration data, as a native ``ruamel.yaml`` map type.
+    username : `str`
+        GitHub username.
+    token : `str`
+        GitHub personal access token belonging to the user.
+    note : `str`, optional
+        Note (YAML comment) to associate with the token field.
+
+    Returns
+    -------
+    config : ``ruamel.yaml.comments.CommentedMap``
+        The configuration data, as a native ``ruamel.yaml`` map type.
+    """
+    config['github'] = CommentedMap({
+        'username': username,
+        'token': token
+    })
+    if token_note is not None:
+        config['github'].yaml_add_eol_comment(token_note, 'token')
+    return config

--- a/tests/TESTR-000/TESTR-000.ipynb
+++ b/tests/TESTR-000/TESTR-000.ipynb
@@ -4,7 +4,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# {{ cookiecutter.title }}\n",
+    "**{{ instance_handle }}**\n",
+    "\n",
+    "# {{ title }}\n",
     "\n",
     "- By: {{ cookiecutter.username }}\n",
     "- Date: {{ cookiecutter.generated_iso8601 }}"

--- a/tests/TESTR-000/cookiecutter.json
+++ b/tests/TESTR-000/cookiecutter.json
@@ -1,5 +1,4 @@
 {
-  "title": "Test Report",
   "username": "Test Bot",
   "generated_iso8601": "2018-07-18",
   "a": 10,

--- a/tests/TESTR-000/nbreport.yaml
+++ b/tests/TESTR-000/nbreport.yaml
@@ -1,3 +1,5 @@
 handle: TESTR-000
 title: Test Report
+git_repo: https://github.com/lsst-sqre/nbreport
+git_repo_subdir: tests/TESTR-000
 ipynb: TESTR-000.ipynb

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 
 from pathlib import Path
 
+from click.testing import CliRunner
 import pytest
 
 
@@ -28,3 +29,10 @@ def testr_000_path():
     """Path to the TESTR-000 report repository.
     """
     return Path(__file__).parent / 'TESTR-000'
+
+
+@pytest.fixture()
+def runner():
+    """Click CliRunner for invoking a command in testing.
+    """
+    return CliRunner()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,3 +36,20 @@ def runner():
     """Click CliRunner for invoking a command in testing.
     """
     return CliRunner()
+
+
+@pytest.fixture()
+def fake_registration():
+    """Creates a callable that adds fake registration metadata to a report
+    repository. This is necessary for creating instances with server-assigned
+    IDs.
+    """
+    def _fake_registration(
+            repo, ltd_product='testr-000',
+            published_url='https://testr-000.lsst.io',
+            ltd_url='https://keeper.lsst.codes/products/testr-000'):
+        repo.config['ltd_product'] = ltd_product
+        repo.config['published_url'] = published_url
+        repo.config['ltd_url'] = ltd_url
+
+    return _fake_registration

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 """Pytest test fixtures.
 """
 
+from pathlib import Path
+
 import pytest
 
 
@@ -19,3 +21,10 @@ def write_user_config():
             fp.write(data)
 
     return _write_user_config
+
+
+@pytest.fixture()
+def testr_000_path():
+    """Path to the TESTR-000 report repository.
+    """
+    return Path(__file__).parent / 'TESTR-000'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,8 @@ def write_user_config():
 def testr_000_path():
     """Path to the TESTR-000 report repository.
     """
-    return Path(__file__).parent / 'TESTR-000'
+    path = Path(__file__).parent / 'TESTR-000'
+    return path.resolve()
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+"""Pytest test fixtures.
+"""
+
+import pytest
+
+
+@pytest.fixture()
+def write_user_config():
+    """Creates a callable that writes a mock .nbreport.yaml file into the
+    current working directory. Used as a pytest fixture.
+    """
+    def _write_user_config(path='.nbreport.yaml'):
+        data = (
+            'github:\n'
+            '  username: testuser\n'
+            '  token: mytoken  # note for token\n'
+        )
+        with open(path, 'w') as fp:
+            fp.write(data)
+
+    return _write_user_config

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,21 +1,16 @@
 """Test the basic nbreport command.
 """
 
-from click.testing import CliRunner
-
 import nbreport
 import nbreport.cli.main
 
 
-def test_version():
+def test_version(runner):
     """Test the version string output.
     """
-    runner = CliRunner()
-
     result = runner.invoke(
         nbreport.cli.main.main,
         ['--version']
     )
     assert result.exit_code == 0
-
     assert result.output == nbreport.__version__ + '\n'

--- a/tests/test_cli_compute.py
+++ b/tests/test_cli_compute.py
@@ -1,0 +1,31 @@
+"""Tests for the nbreport compute command.
+"""
+
+from pathlib import Path
+
+import nbreport.cli.main
+from nbreport.repo import ReportRepo
+from nbreport.processing import create_instance
+
+
+def test_compute_command(testr_000_path, runner):
+    """Test the nbreport compute command.
+    """
+    with runner.isolated_filesystem():
+        repo = ReportRepo(testr_000_path)
+        instance = create_instance(
+            repo,
+            instance_id='test',
+            template_variables={},
+            instance_path=Path('TESTR-000-test'))
+
+        args = [
+            'compute',  # subcommand
+            str(instance.dirname),  # first argument
+        ]
+        result = runner.invoke(nbreport.cli.main.main, args)
+        assert result.exit_code == 0
+
+        # Check that the notebook was computed and saved
+        nb = instance.open_notebook()
+        assert nb.cells[1].outputs[0].text == 'The answer is 42\n'

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -40,7 +40,6 @@ def test_init_command(write_user_config, testr_000_path, runner,
             '--config-file', '.nbreport.yaml',
             'init',  # subcommand
             str(repo_path),  # first argument
-            '-c', 'title', 'My sick report',
             '-c', 'a', '100',
             '-c', 'b', '200',
         ]
@@ -56,8 +55,6 @@ def test_init_command(write_user_config, testr_000_path, runner,
         # Check that the cookiecutter.json context got added to nbreport.yaml
         # This is just a sampling of the expected context
         assert 'context' in instance.config
-        assert instance.config['context']['cookiecutter']['title'] \
-            == 'My sick report'
         assert instance.config['context']['cookiecutter']['username'] \
             == 'Test Bot'
         assert instance.config['context']['cookiecutter']['a'] == '100'
@@ -67,8 +64,8 @@ def test_init_command(write_user_config, testr_000_path, runner,
 
         # Check that the cells got rendered
         assert nb.cells[0].source == (
-            "# My sick report\n"
-            "\n"
+            "**TESTR-000-1**\n\n"
+            "# Test Report\n\n"
             "- By: Test Bot\n"
             "- Date: 2018-07-18"
         )
@@ -120,7 +117,8 @@ def test_init_command_no_template_vars(
 
         nb = instance.open_notebook()
         assert nb.cells[0].source == (
-            "# {{ cookiecutter.title }}\n"
+            "**{{ instance_handle }}**\n\n"
+            "# {{ title }}\n"
             "\n"
             "- By: {{ cookiecutter.username }}\n"
             "- Date: {{ cookiecutter.generated_iso8601 }}"

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -1,0 +1,27 @@
+"""Tests for the ``nbreport init`` command.
+"""
+
+from pathlib import Path
+import shutil
+
+# import nbreport.cli.main
+
+from click.testing import CliRunner
+import responses
+
+
+@responses.activate
+def test_init_command(write_user_config, testr_000_path):
+    """Test creating a new report instance.
+    """
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        # Copy the repo into workspace
+        # copy the repo into this isolated workspace
+        repo_path = Path.cwd() / 'TESTR-000'
+        shutil.copytree(str(testr_000_path), str(repo_path))
+        assert repo_path.exists()
+
+        # Fake the repo's registration
+        # TODO

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -4,18 +4,24 @@
 from pathlib import Path
 import shutil
 
-# import nbreport.cli.main
+import nbreport.cli.main
+from nbreport.repo import ReportRepo
+from nbreport.instance import ReportInstance
 
-from click.testing import CliRunner
 import responses
 
 
 @responses.activate
-def test_init_command(write_user_config, testr_000_path):
+def test_init_command(write_user_config, testr_000_path, runner,
+                      fake_registration):
     """Test creating a new report instance.
     """
+    responses.add(
+        responses.POST,
+        'https://api.lsst.codes/nbreport/reports/testr-000/instances/',
+        json={'instance_id': '1'},
+        status=201)
 
-    runner = CliRunner()
     with runner.isolated_filesystem():
         # Copy the repo into workspace
         # copy the repo into this isolated workspace
@@ -23,5 +29,83 @@ def test_init_command(write_user_config, testr_000_path):
         shutil.copytree(str(testr_000_path), str(repo_path))
         assert repo_path.exists()
 
-        # Fake the repo's registration
-        # TODO
+        # Make a repo with faked registration
+        repo = ReportRepo(repo_path)
+        fake_registration(repo)
+
+        # Create a mock .nbreport.yaml file with auth data
+        write_user_config('.nbreport.yaml')
+
+        args = [
+            '--config-file', '.nbreport.yaml',
+            'init',  # subcommand
+            str(repo_path),  # first argument
+            '-c', 'title', 'My sick report',
+            '-c', 'a', '100',
+            '-c', 'b', '200',
+        ]
+        result = runner.invoke(nbreport.cli.main.main, args)
+        assert result.exit_code == 0
+
+        instance_path = Path('TESTR-000-1')
+        assert instance_path.exists()
+        instance = ReportInstance(instance_path)
+        assert instance.config['instance_id'] == '1'
+        assert instance.config['instance_handle'] == 'TESTR-000-1'
+
+        nb = instance.open_notebook()
+        assert nb.cells[0].source == (
+            "# My sick report\n"
+            "\n"
+            "- By: Test Bot\n"
+            "- Date: 2018-07-18"
+        )
+
+
+@responses.activate
+def test_init_command_no_template_vars(
+        write_user_config, testr_000_path, runner, fake_registration):
+    """Test creating a new report instance, but without rendering the
+    template variables.
+    """
+    responses.add(
+        responses.POST,
+        'https://api.lsst.codes/nbreport/reports/testr-000/instances/',
+        json={'instance_id': '1'},
+        status=201)
+
+    with runner.isolated_filesystem():
+        # Copy the repo into workspace
+        # copy the repo into this isolated workspace
+        repo_path = Path.cwd() / 'TESTR-000'
+        shutil.copytree(str(testr_000_path), str(repo_path))
+        assert repo_path.exists()
+
+        # Make a repo with faked registration
+        repo = ReportRepo(repo_path)
+        fake_registration(repo)
+
+        # Create a mock .nbreport.yaml file with auth data
+        write_user_config('.nbreport.yaml')
+
+        args = [
+            '--config-file', '.nbreport.yaml',
+            'init',  # subcommand
+            str(repo_path),  # first argument
+        ]
+        result = runner.invoke(nbreport.cli.main.main, args)
+        assert result.exit_code == 0
+
+        instance_path = Path('TESTR-000-1')
+        assert instance_path.exists()
+        instance = ReportInstance(instance_path)
+        assert instance.config['instance_id'] == '1'
+        assert instance.config['instance_handle'] == 'TESTR-000-1'
+
+        nb = instance.open_notebook()
+        assert nb.cells[0].source == (
+            "# {{ cookiecutter.title }}\n"
+            "\n"
+            "- By: {{ cookiecutter.username }}\n"
+            "- Date: {{ cookiecutter.generated_iso8601 }}"
+        )

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -53,13 +53,29 @@ def test_init_command(write_user_config, testr_000_path, runner,
         assert instance.config['instance_id'] == '1'
         assert instance.config['instance_handle'] == 'TESTR-000-1'
 
+        # Check that the cookiecutter.json context got added to nbreport.yaml
+        # This is just a sampling of the expected context
+        assert 'context' in instance.config
+        assert instance.config['context']['cookiecutter']['title'] \
+            == 'My sick report'
+        assert instance.config['context']['cookiecutter']['username'] \
+            == 'Test Bot'
+        assert instance.config['context']['cookiecutter']['a'] == '100'
+        assert instance.config['context']['cookiecutter']['b'] == '200'
+
         nb = instance.open_notebook()
+
+        # Check that the cells got rendered
         assert nb.cells[0].source == (
             "# My sick report\n"
             "\n"
             "- By: Test Bot\n"
             "- Date: 2018-07-18"
         )
+
+        # Check that the instance config got added to the notebook metadata
+        # (sampling keys)
+        assert 'nbreport' in nb.metadata
 
 
 @responses.activate

--- a/tests/test_cli_issue.py
+++ b/tests/test_cli_issue.py
@@ -48,7 +48,6 @@ def test_issue(write_user_config, testr_000_path, runner,
             '--config-file', '.nbreport.yaml',
             'issue',  # subcommand
             str(repo_path),  # first argument
-            '-c', 'title', 'My sick report',
             '-c', 'a', '100',
             '-c', 'b', '200',
         ]
@@ -65,8 +64,8 @@ def test_issue(write_user_config, testr_000_path, runner,
             upload_request.body.decode('utf-8'),
             as_version=nbformat.NO_CONVERT)
         assert nb.cells[0].source == (
-            "# My sick report\n"
-            "\n"
+            "**TESTR-000-1**\n\n"
+            "# Test Report\n\n"
             "- By: Test Bot\n"
             "- Date: 2018-07-18"
         )

--- a/tests/test_cli_issue.py
+++ b/tests/test_cli_issue.py
@@ -1,0 +1,73 @@
+"""Tests for the ``nbreport issue`` command.
+"""
+
+from pathlib import Path
+import shutil
+
+import nbformat
+import responses
+
+import nbreport.cli.main
+from nbreport.repo import ReportRepo
+
+
+@responses.activate
+def test_issue(write_user_config, testr_000_path, runner,
+               fake_registration):
+    """Test a typical nbreport issue command with the tests/TESTR-000 repo.
+    """
+    responses.add(
+        responses.POST,
+        'https://api.lsst.codes/nbreport/reports/testr-000/instances/',
+        json={'instance_id': '1'},
+        status=201)
+    responses.add(
+        responses.POST,
+        'https://api.lsst.codes/nbreport/reports/testr-000/'
+        'instances/1/notebook',
+        json={
+            'ltd_edition_url': 'https://keeper.lsst.codes/editions/12345',
+            'published_url': 'https://testr-000.lsst.io/v/1'
+        },
+        status=202)
+
+    with runner.isolated_filesystem():
+        # Copy the repo into this isolated workspace
+        repo_path = Path.cwd() / 'TESTR-000'
+        shutil.copytree(str(testr_000_path), str(repo_path))
+        assert repo_path.exists()
+
+        # Make a repo with faked registration
+        repo = ReportRepo(repo_path)
+        fake_registration(repo)
+
+        # Create a mock .nbreport.yaml file with auth data
+        write_user_config('.nbreport.yaml')
+
+        args = [
+            '--config-file', '.nbreport.yaml',
+            'issue',  # subcommand
+            str(repo_path),  # first argument
+            '-c', 'title', 'My sick report',
+            '-c', 'a', '100',
+            '-c', 'b', '200',
+        ]
+        result = runner.invoke(nbreport.cli.main.main, args)
+        assert result.exit_code == 0
+
+        upload_request = responses.calls[1].request
+        assert upload_request.url == (
+            'https://api.lsst.codes/nbreport/reports/testr-000/'
+            'instances/1/notebook')
+
+        # Check that the notebook *sent to the server* is computed properly
+        nb = nbformat.reads(
+            upload_request.body.decode('utf-8'),
+            as_version=nbformat.NO_CONVERT)
+        assert nb.cells[0].source == (
+            "# My sick report\n"
+            "\n"
+            "- By: Test Bot\n"
+            "- Date: 2018-07-18"
+        )
+        assert nb.cells[1].outputs[0].text == 'The answer is 300\n'

--- a/tests/test_cli_login.py
+++ b/tests/test_cli_login.py
@@ -3,7 +3,6 @@
 
 from pathlib import Path
 
-from click.testing import CliRunner
 import pytest
 import responses
 
@@ -12,7 +11,7 @@ import nbreport.cli.main
 
 
 @responses.activate
-def test_login_command():
+def test_login_command(runner):
     """Test the nbreport login command (with mocks).
     """
     responses.add(
@@ -22,7 +21,6 @@ def test_login_command():
               'note': 'note for token'},
         status=201)
 
-    runner = CliRunner()
     with runner.isolated_filesystem():
         args = [
             '--config-file', 'nbreport.yaml',  # test-local config file

--- a/tests/test_cli_login.py
+++ b/tests/test_cli_login.py
@@ -3,11 +3,46 @@
 
 from pathlib import Path
 
+from click.testing import CliRunner
 import pytest
 import responses
 
 from nbreport.cli.login import request_github_token, GitHubTwoFactorRequired
-from nbreport.cli.login import write_token
+import nbreport.cli.main
+
+
+@responses.activate
+def test_login_command():
+    """Test the nbreport login command (with mocks).
+    """
+    responses.add(
+        responses.POST,
+        'https://api.github.com/authorizations',
+        json={'token': 'mytoken',
+              'note': 'note for token'},
+        status=201)
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        args = [
+            '--config-file', 'nbreport.yaml',  # test-local config file
+            'login',  # subcommand
+            '--name', 'testuser',
+            '--password', 'testpassword'
+        ]
+        result = runner.invoke(nbreport.cli.main.main, args)
+        assert result.exit_code == 0
+
+        config_path = Path('nbreport.yaml')
+        assert config_path.exists()
+
+        with open(config_path) as fp:
+            config_text = fp.read()
+        assert config_text == (
+            'github:\n'
+            '  username: testuser\n'
+            '  token: mytoken  # note for token\n'
+        )
 
 
 @responses.activate
@@ -65,33 +100,3 @@ def test_request_github_token_with_2fa():
         == 'https://api.github.com/authorizations'
     assert data['token'] == 'mytoken'
     assert data['note'] == 'note for token'
-
-
-def test_write_token(tmpdir):
-    """Test writing and re-writing .nbreport.yaml with github auth info.
-    """
-    username = 'exampleuser'
-    token = 'example'
-    note = 'note example'
-    path = Path(tmpdir) / '.nbreport.yaml'
-
-    write_token(username, token, note, path=path)
-
-    with open(path) as fp:
-        config_text = fp.read()
-    assert config_text == (
-        'github:\n'
-        '  username: exampleuser\n'
-        '  token: example  # note example\n'
-    )
-
-    # Now re-write the token to ensure we can re-write one
-    write_token(username, 'newtoken', note, path=path)
-
-    with open(path) as fp:
-        config_text = fp.read()
-    assert config_text == (
-        'github:\n'
-        '  username: exampleuser\n'
-        '  token: newtoken  # note example\n'
-    )

--- a/tests/test_cli_register.py
+++ b/tests/test_cli_register.py
@@ -1,0 +1,61 @@
+"""Tests for the ``nbreport register`` command.
+"""
+
+from pathlib import Path
+import shutil
+
+from click.testing import CliRunner
+import responses
+
+import nbreport.cli.main
+from nbreport.repo import ReportRepo
+
+
+@responses.activate
+def test_register_command(write_user_config):
+    """Test with no arguments except repo path.
+    """
+    responses.add(
+        responses.POST,
+        'https://api.lsst.codes/nbreport/reports/',
+        json={'product': 'testr-000',
+              'published_url': 'https://testr-000.lsst.io',
+              'product_url': 'https://keeper.lsst.codes/products/testr-000'},
+        status=201)
+
+    original_repo_path = Path(__file__).parent / 'TESTR-000'
+    original_repo_path = original_repo_path.resolve()
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        # copy the repo into this isolated workspace
+        repo_path = Path.cwd() / 'TESTR-000'
+        shutil.copytree(
+            str(original_repo_path),
+            str(repo_path))
+        assert repo_path.exists()
+
+        # Create a mock .nbreport.yaml file with auth data
+        write_user_config('.nbreport.yaml')
+
+        args = [
+            '--config-file', '.nbreport.yaml',
+            'register',  # subcommand
+            str(repo_path),  # first argument
+        ]
+        result = runner.invoke(nbreport.cli.main.main, args, input='y\n')
+
+        assert result.exit_code == 0
+
+        # Test modifications to repo's nbreport.yaml
+        repo = ReportRepo(repo_path)
+        assert repo.config['ltd_product'] == 'testr-000'
+        assert repo.config['ltd_url'] \
+            == 'https://keeper.lsst.codes/products/testr-000'
+        assert repo.config['published_url'] == 'https://testr-000.lsst.io'
+        assert repo.config['handle'] == 'TESTR-000'
+        assert repo.config['title'] == 'Test Report'
+        assert repo.config['git_repo'] \
+            == 'https://github.com/lsst-sqre/nbreport'
+        assert repo.config['git_repo_subdir'] \
+            == 'tests/TESTR-000'

--- a/tests/test_cli_register.py
+++ b/tests/test_cli_register.py
@@ -4,7 +4,6 @@
 from pathlib import Path
 import shutil
 
-from click.testing import CliRunner
 import responses
 
 import nbreport.cli.main
@@ -12,7 +11,7 @@ from nbreport.repo import ReportRepo
 
 
 @responses.activate
-def test_register_command(write_user_config, testr_000_path):
+def test_register_command(write_user_config, testr_000_path, runner):
     """Test with no arguments except repo path.
     """
     responses.add(
@@ -23,7 +22,6 @@ def test_register_command(write_user_config, testr_000_path):
               'product_url': 'https://keeper.lsst.codes/products/testr-000'},
         status=201)
 
-    runner = CliRunner()
     with runner.isolated_filesystem():
         # copy the repo into this isolated workspace
         repo_path = Path.cwd() / 'TESTR-000'

--- a/tests/test_cli_register.py
+++ b/tests/test_cli_register.py
@@ -12,7 +12,7 @@ from nbreport.repo import ReportRepo
 
 
 @responses.activate
-def test_register_command(write_user_config):
+def test_register_command(write_user_config, testr_000_path):
     """Test with no arguments except repo path.
     """
     responses.add(
@@ -23,16 +23,11 @@ def test_register_command(write_user_config):
               'product_url': 'https://keeper.lsst.codes/products/testr-000'},
         status=201)
 
-    original_repo_path = Path(__file__).parent / 'TESTR-000'
-    original_repo_path = original_repo_path.resolve()
-
     runner = CliRunner()
     with runner.isolated_filesystem():
         # copy the repo into this isolated workspace
         repo_path = Path.cwd() / 'TESTR-000'
-        shutil.copytree(
-            str(original_repo_path),
-            str(repo_path))
+        shutil.copytree(str(testr_000_path), str(repo_path))
         assert repo_path.exists()
 
         # Create a mock .nbreport.yaml file with auth data

--- a/tests/test_cli_test.py
+++ b/tests/test_cli_test.py
@@ -1,44 +1,36 @@
 """Test the nbreport test CLI (nbreport.cli.test).
 """
 
-from pathlib import Path
-
 from click.testing import CliRunner
 
 import nbreport.cli.main
 from nbreport.instance import ReportInstance
 
 
-def test_basic(tmpdir):
+def test_basic(testr_000_path):
     """Test with no arguments except repo path.
     """
     runner = CliRunner()
 
-    repo_path = Path(__file__).parent / 'TESTR-000'
-    repo_path = repo_path.resolve()
-
     with runner.isolated_filesystem():
         args = [
             'test',  # subcommand
-            str(repo_path),  # first argument
+            str(testr_000_path),  # first argument
         ]
         result = runner.invoke(nbreport.cli.main.main, args)
 
         assert result.exit_code == 0
 
 
-def test_basic_with_dirname_arg(tmpdir):
+def test_basic_with_dirname_arg(testr_000_path):
     """Test with --id and -d arguments.
     """
     runner = CliRunner()
 
-    repo_path = Path(__file__).parent / 'TESTR-000'
-    repo_path = repo_path.resolve()
-
     with runner.isolated_filesystem():
         args = [
             'test',  # subcommand
-            str(repo_path),  # first argument
+            str(testr_000_path),  # first argument
             '--id', '1',
             '-d', 'TESTR-000-1',
         ]
@@ -47,19 +39,16 @@ def test_basic_with_dirname_arg(tmpdir):
         assert result.exit_code == 0
 
 
-def test_config_option(tmpdir):
+def test_config_option(testr_000_path):
     """Test with config (-c) options to configure the template rendering.
     """
     runner = CliRunner()
-
-    repo_path = Path(__file__).parent / 'TESTR-000'
-    repo_path = repo_path.resolve()
 
     with runner.isolated_filesystem():
         args = [
             '--log-level', 'debug',
             'test',  # subcommand
-            str(repo_path),  # first argument
+            str(testr_000_path),  # first argument
             '-c', 'title', 'My sick report',
             '-c', 'a', '100',
             '-c', 'b', '200',
@@ -84,7 +73,7 @@ def test_config_option(tmpdir):
         )
 
 
-def test_from_git_clone(tmpdir):
+def test_from_git_clone():
     """Test creating an instance from a GitHub original repository.
     """
     runner = CliRunner()

--- a/tests/test_cli_test.py
+++ b/tests/test_cli_test.py
@@ -41,7 +41,6 @@ def test_config_option(testr_000_path, runner):
             '--log-level', 'debug',
             'test',  # subcommand
             str(testr_000_path),  # first argument
-            '-c', 'title', 'My sick report',
             '-c', 'a', '100',
             '-c', 'b', '200',
         ]
@@ -54,8 +53,8 @@ def test_config_option(testr_000_path, runner):
         nb = instance.open_notebook()
 
         assert nb.cells[0].source == (
-            "# My sick report\n"
-            "\n"
+            "**TESTR-000-test**\n\n"
+            "# Test Report\n\n"
             "- By: Test Bot\n"
             "- Date: 2018-07-18"
         )
@@ -75,7 +74,6 @@ def test_from_git_clone(runner):
             'https://github.com/lsst-sqre/nbreport',
             '--git-ref', 'master',
             '--git-subdir', 'tests/TESTR-000',
-            '-c', 'title', 'My sick report',
             '-c', 'a', '100',
             '-c', 'b', '200',
         ]

--- a/tests/test_cli_test.py
+++ b/tests/test_cli_test.py
@@ -1,17 +1,13 @@
 """Test the nbreport test CLI (nbreport.cli.test).
 """
 
-from click.testing import CliRunner
-
 import nbreport.cli.main
 from nbreport.instance import ReportInstance
 
 
-def test_basic(testr_000_path):
+def test_basic(testr_000_path, runner):
     """Test with no arguments except repo path.
     """
-    runner = CliRunner()
-
     with runner.isolated_filesystem():
         args = [
             'test',  # subcommand
@@ -22,11 +18,9 @@ def test_basic(testr_000_path):
         assert result.exit_code == 0
 
 
-def test_basic_with_dirname_arg(testr_000_path):
+def test_basic_with_dirname_arg(testr_000_path, runner):
     """Test with --id and -d arguments.
     """
-    runner = CliRunner()
-
     with runner.isolated_filesystem():
         args = [
             'test',  # subcommand
@@ -39,11 +33,9 @@ def test_basic_with_dirname_arg(testr_000_path):
         assert result.exit_code == 0
 
 
-def test_config_option(testr_000_path):
+def test_config_option(testr_000_path, runner):
     """Test with config (-c) options to configure the template rendering.
     """
-    runner = CliRunner()
-
     with runner.isolated_filesystem():
         args = [
             '--log-level', 'debug',
@@ -73,11 +65,9 @@ def test_config_option(testr_000_path):
         )
 
 
-def test_from_git_clone():
+def test_from_git_clone(runner):
     """Test creating an instance from a GitHub original repository.
     """
-    runner = CliRunner()
-
     with runner.isolated_filesystem():
         args = [
             '--log-level', 'debug',

--- a/tests/test_cli_upload.py
+++ b/tests/test_cli_upload.py
@@ -1,0 +1,69 @@
+"""Tests for the ``nbreport upload`` command.
+"""
+
+from pathlib import Path
+import shutil
+
+import responses
+
+import nbreport.cli.main
+from nbreport.repo import ReportRepo
+from nbreport.compute import compute_notebook_file
+from nbreport.processing import create_instance
+
+
+@responses.activate
+def test_upload(write_user_config, testr_000_path, runner, fake_registration):
+    responses.add(
+        responses.POST,
+        'https://api.lsst.codes/nbreport/reports/testr-000/'
+        'instances/test/notebook',
+        json={
+            'ltd_edition_url': 'https://keeper.lsst.codes/editions/12345',
+            'published_url': 'https://testr-000.lsst.io/v/test'
+        },
+        status=202)
+
+    with runner.isolated_filesystem():
+        # Copy the repo into this isolated workspace
+        repo_path = Path.cwd() / 'TESTR-000'
+        shutil.copytree(str(testr_000_path), str(repo_path))
+        assert repo_path.exists()
+
+        # Make a repo with faked registration
+        repo = ReportRepo(repo_path)
+        fake_registration(repo)
+
+        # Create a mock .nbreport.yaml file with auth data
+        write_user_config('.nbreport.yaml')
+
+        instance = create_instance(
+            repo,
+            instance_id='test',
+            template_variables={},
+            instance_path=Path('TESTR-000-test'))
+
+        compute_notebook_file(instance.ipynb_path)
+
+        args = [
+            '--config-file', '.nbreport.yaml',
+            'upload',
+            str(instance.dirname)
+        ]
+
+        result = runner.invoke(nbreport.cli.main.main, args)
+        print(result.output)
+        assert result.exit_code == 0
+
+        request = responses.calls[0].request
+        assert request.url == (
+            'https://api.lsst.codes/nbreport/reports/testr-000/'
+            'instances/test/notebook')
+        assert request.headers['Content-Type'] == 'application/x-ipynb+json'
+
+        with open(instance.ipynb_path, 'rb') as fp:
+            nbdata = fp.read()
+            assert request.body == nbdata
+
+        assert instance.config['published_instance_url'] \
+            == 'https://testr-000.lsst.io/v/test'

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -10,15 +10,14 @@ from nbreport.instance import ReportInstance
 from nbreport.repo import ReportRepo
 
 
-def test_report_repo(tmpdir):
+def test_report_repo(tmpdir, testr_000_path):
     """Test ReportRepo on the ``/tests/TESTR-000`` path.
     """
-    repo_path = Path(__file__).parent / 'TESTR-000'
-    repo = ReportRepo(repo_path)
-
+    repo = ReportRepo(testr_000_path)
     instance_dirname = Path(str(tmpdir)) / 'TESTR-000-1'
 
-    instance = ReportInstance.from_report_repo(repo, instance_dirname, '1')
+    instance = ReportInstance.from_report_repo(
+        repo, instance_dirname, '1')
 
     assert instance.dirname == instance_dirname
     assert instance.dirname.exists()
@@ -32,11 +31,10 @@ def test_report_repo(tmpdir):
     assert instance2.dirname == instance_dirname
 
 
-def test_report_repo_overwrite(tmpdir):
+def test_report_repo_overwrite(tmpdir, testr_000_path):
     """Test modes for overwriting an existing instance directory.
     """
-    repo_path = Path(__file__).parent / 'TESTR-000'
-    repo = ReportRepo(repo_path)
+    repo = ReportRepo(testr_000_path)
     instance_dirname = Path(str(tmpdir)) / 'TESTR-000-1'
     instance = ReportInstance.from_report_repo(repo, instance_dirname, '1')
     assert instance.dirname == instance_dirname

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -67,6 +67,8 @@ def test_report_config_read():
     assert str(repo.config) == (
         'handle: TESTR-000\n'
         'title: Test Report\n'
+        'git_repo: https://github.com/lsst-sqre/nbreport\n'
+        'git_repo_subdir: tests/TESTR-000\n'
         'ipynb: TESTR-000.ipynb\n'
     )
 

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -99,3 +99,7 @@ def test_report_config_write(tmpdir):
     # Test __setitem__
     config['title'] = 'Revised Test Report'
     assert config['title'] == 'Revised Test Report'
+
+    # Test __contains__
+    assert 'title' in config
+    assert 'not-here' not in config

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -9,27 +9,24 @@ import pytest
 from nbreport.repo import ReportRepo, ReportConfig
 
 
-def test_report_repo():
+def test_report_repo(testr_000_path):
     """Test ReportRepo on the ``/tests/TESTR-000`` path.
     """
-    repo_path = Path(__file__).parent / 'TESTR-000'
+    repo = ReportRepo(testr_000_path)
 
-    repo = ReportRepo(repo_path)
-
-    assert repo.dirname == repo_path
-    assert repo.context_path == repo_path / 'cookiecutter.json'
-    assert repo.config_path == repo_path / 'nbreport.yaml'
+    assert repo.dirname == testr_000_path
+    assert repo.context_path == testr_000_path / 'cookiecutter.json'
+    assert repo.config_path == testr_000_path / 'nbreport.yaml'
     assert isinstance(repo.config, ReportConfig)
     assert isinstance(repo.open_notebook(), nbformat.NotebookNode)
 
 
-def test_report_repo_from_str():
+def test_report_repo_from_str(testr_000_path):
     """Test creating a ReportRepo on the ``/tests/TESTR-000`` path from a
     string.
     """
-    repo_path = Path(__file__).parent / 'TESTR-000'
-    repo = ReportRepo(str(repo_path))
-    assert repo.dirname == repo_path
+    repo = ReportRepo(str(testr_000_path))
+    assert repo.dirname == testr_000_path
 
 
 def test_report_repo_not_found():
@@ -52,11 +49,10 @@ def test_report_repo_git_clone(tmpdir):
     assert repo.ipynb_path.exists()
 
 
-def test_report_config_read():
+def test_report_config_read(testr_000_path):
     """Test reading the ReportConfig using ``/tests/TESTR-000/nbreport.yaml``.
     """
-    repo_path = Path(__file__).parent / 'TESTR-000'
-    repo = ReportRepo(repo_path)
+    repo = ReportRepo(testr_000_path)
     assert repo.config['handle'] == 'TESTR-000'
     assert repo.config['title'] == 'Test Report'
     assert repo.config['ipynb'] == 'TESTR-000.ipynb'

--- a/tests/test_templating.py
+++ b/tests/test_templating.py
@@ -1,8 +1,6 @@
 """Tests for the nbreport.templating module.
 """
 
-from pathlib import Path
-
 import nbformat
 import pytest
 
@@ -69,15 +67,14 @@ def test_render_notebook():
     'use_pathlib',
     [(True,), (False,)]
 )
-def test_load_template_environment_from_fs(use_pathlib):
+def test_load_template_environment_from_fs(use_pathlib, testr_000_path):
     """Test loading the template environment in tests/TESTR-000 using the
     ``cookiecutter.json`` file as context.
 
     Test passing the context file's path as both a pathlib.Path and as a
     string.
     """
-    base_dir = Path(__file__).parent / 'TESTR-000'
-    context_path = base_dir / 'cookiecutter.json'
+    context_path = testr_000_path / 'cookiecutter.json'
 
     if not use_pathlib:
         context_path = str(context_path)
@@ -98,16 +95,15 @@ def test_load_empty_template_environment():
     assert len(context['cookiecutter'].keys()) == 0
 
 
-def test_render_ipynb():
+def test_render_ipynb(testr_000_path):
     """Proof-of-concept for rendering the templated ipynb notebook in
     ``tests/TESTR-000/``.
 
     This test exercises obtaining a context from the cookiecutter.json file,
     and rendering a full ipynb given that context.
     """
-    base_dir = Path(__file__).parent / 'TESTR-000'
-    context_path = base_dir / 'cookiecutter.json'
-    ipynb_path = base_dir / 'TESTR-000.ipynb'
+    context_path = testr_000_path / 'cookiecutter.json'
+    ipynb_path = testr_000_path / 'TESTR-000.ipynb'
 
     context, jinja_env = load_template_environment(context_path=context_path)
     notebook = nbformat.read(str(ipynb_path.resolve()),

--- a/tests/test_templating.py
+++ b/tests/test_templating.py
@@ -81,7 +81,6 @@ def test_load_template_environment_from_fs(use_pathlib, testr_000_path):
 
     context, jinja_env = load_template_environment(context_path=context_path)
 
-    assert context['cookiecutter']['title'] == 'Test Report'
     assert context['cookiecutter']['username'] == 'Test Bot'
     assert context['cookiecutter']['generated_iso8601'] == '2018-07-18'
     assert context['cookiecutter']['a'] == 10
@@ -93,31 +92,3 @@ def test_load_empty_template_environment():
     """
     context, jinja_env = load_template_environment()
     assert len(context['cookiecutter'].keys()) == 0
-
-
-def test_render_ipynb(testr_000_path):
-    """Proof-of-concept for rendering the templated ipynb notebook in
-    ``tests/TESTR-000/``.
-
-    This test exercises obtaining a context from the cookiecutter.json file,
-    and rendering a full ipynb given that context.
-    """
-    context_path = testr_000_path / 'cookiecutter.json'
-    ipynb_path = testr_000_path / 'TESTR-000.ipynb'
-
-    context, jinja_env = load_template_environment(context_path=context_path)
-    notebook = nbformat.read(str(ipynb_path.resolve()),
-                             as_version=nbformat.NO_CONVERT)
-
-    notebook = render_notebook(notebook, context, jinja_env)
-
-    assert notebook.cells[0].source == (
-        '# Test Report\n'
-        '\n'
-        '- By: Test Bot\n'
-        '- Date: 2018-07-18'
-    )
-    assert notebook.cells[1].source == (
-        "answer = 10 + 32\n"
-        "print('The answer is {}'.format(answer))"
-    )


### PR DESCRIPTION
- Several new commands were added that make the ``nbreport`` command line client fully functional:

  - ``nbreport register`` command registers a report repo with LSST the Docs so that instances can be published.

  - ``nbreport init`` command initializes a new report instance (by reserving a number with the API server and optionally rendering template variables).

  - ``nbreport compute`` command computes a report instance's notebook.

  - ``nbreport upload`` command uploads a report instance to the API server, which publishes it to LSST the Docs.

  - ``nbreport issue`` command performs the equivalent of ``init``, ``compute``, and ``upload`` in a single step.

- Key metadata from each instance ``nbreport.yaml`` file is not available as a Jinja template variable, namely: ``handle``, ``title``, ``git_repo``, ``git_repo_subdir``, ``instance_id``, ``instance_handle``.
  These variables aren't part of the ``cookiecutter`` namespace and can't be overridden on the command line.

- Metadata from ``nbreport.yaml``, as well as the final set of ``cookiecutter`` template variables, are included in the notebook files's metadata.
  This provides a record of how the notebook was constructed, and will be used on the server to both render the notebook page and to provide filtering of notebooks.

- Refactored code related to reading ``~/.nbreport.yaml`` out of the ``nbreport login`` command and into the ``nbreport.userconfig`` module.
  The main command reads this file and passes data like the authentication token to subcommands.

- Refactored ``create_instance()`` out of the ``nbreport test`` command and into ``nbreport.processing`` so that multiple subcommands (``init``, ``issue``) can consume it.
