### PR TITLE
DM-15416: Integration improvements with api.lsst.codes/nbreport

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,35 @@
 Change log
 ##########
 
+0.7.0 (2018-08-12)
+==================
+
+This release fixes issues related to the integration of this ``nbreport`` command line client with the ``api.lsst.codes/nbreport`` backend microservice.
+
+*New features:*
+
+- Added the ``nbreport render`` command that renders the templated notebook of an initialized notebook instance that wasn't initially rendered (because no template variables were specified).
+
+- Improved user messages from commands.
+
+*Fixes:*
+
+- Fixed bugs in ``nbreport.compute``.
+
+- ``nbreport register`` now sends authentication data.
+
+- The instance URL (``published_instance_url``) and API URL (``ltd_edition_url``) are now obtained during instance initialization.
+  This matches when that data is readily available from the ``api.lsst.codes/nbreport`` backend microservice.
+
+- Replace ``context`` with ``cookiecutter`` in an instance's ``nbreport.yaml`` field.
+  By only reporting data from the ``cookiecutter`` template context in ``nbreport.yaml``, we avoid duplicating information that's copied into the template context, like ``instance_id`` and ``handle``.
+
+- More thoroughly cast config to JSON-serializable dict when inserting the ``nbreport.yaml`` instance metadata into the notebook's metadata.
+  In ruamel.yaml 0.15.52 (2018-08-09), the CommentedMap type is no longer a subclass of OrderedDict.
+  This meant that the configs were no longer JSON-serializable when directly inserted into notebook metadata.
+
+`DM-15416 <https://jira.lsstcorp.org/browse/DM-15416>`__.
+
 0.6.0 (2018-08-08)
 ==================
 

--- a/nbreport/cli/compute.py
+++ b/nbreport/cli/compute.py
@@ -37,3 +37,4 @@ def compute(ctx, instance_path, timeout, kernel):
     instance = ReportInstance(instance_path)
     compute_notebook_file(instance.ipynb_path, timeout=timeout,
                           kernel_name=kernel)
+    click.echo('Complete.')

--- a/nbreport/cli/init.py
+++ b/nbreport/cli/init.py
@@ -102,5 +102,5 @@ def init(ctx, repo_path_or_url, template_variables, instance_path,
 
     if template_variables is None:
         click.echo(
-            'Run nbreport render {0!s} (with -c options) to render '
+            'Run\n  nbreport render {0!s}\n(with -c options) to render '
             'the instance’s templated cells.'.format(instance.dirname))

--- a/nbreport/cli/issue.py
+++ b/nbreport/cli/issue.py
@@ -87,12 +87,13 @@ def issue(ctx, repo_path_or_url, template_variables, instance_path, timeout,
     compute_notebook_file(instance.ipynb_path, timeout=timeout,
                           kernel_name=kernel)
 
-    instance.upload(
+    queue_url = instance.upload(
         github_username=ctx.obj['config']['github']['username'],
         github_token=ctx.obj['config']['github']['token'],
         server=ctx.obj['server'])
 
     click.echo('Issued report instance {}.'.format(
         instance.config['instance_handle']))
+    click.echo('Upload complete. Status: {}'.format(queue_url))
     click.echo('Report is being published to {}'.format(
         instance.config['published_instance_url']))

--- a/nbreport/cli/issue.py
+++ b/nbreport/cli/issue.py
@@ -94,6 +94,6 @@ def issue(ctx, repo_path_or_url, template_variables, instance_path, timeout,
 
     click.echo('Issued report instance {}.'.format(
         instance.config['instance_handle']))
-    click.echo('Upload complete. Status: {}'.format(queue_url))
-    click.echo('Report is being published to {}'.format(
+    click.echo('Processing status:\n  {}'.format(queue_url))
+    click.echo('Publication URL:\n  {}'.format(
         instance.config['published_instance_url']))

--- a/nbreport/cli/main.py
+++ b/nbreport/cli/main.py
@@ -16,6 +16,7 @@ from .init import init
 from .issue import issue
 from .test import test
 from .upload import upload
+from .render import render
 
 
 # Add -h as a help shortcut option
@@ -93,6 +94,7 @@ def help(ctx, topic, **kw):
 main.add_command(login)
 main.add_command(register)
 main.add_command(init)
+main.add_command(render)
 main.add_command(compute)
 main.add_command(upload)
 main.add_command(issue)

--- a/nbreport/cli/register.py
+++ b/nbreport/cli/register.py
@@ -49,9 +49,9 @@ def register(ctx, repo_path):
 
     # Allow for user confirmation
     click.echo('Registering report with this metadata from nbreport.yaml:')
-    click.echo('\tHandle: {}'.format(handle))
-    click.echo('\tTitle: {}'.format(title))
-    click.echo('\tGit repository: {}'.format(git_repo))
+    click.echo('  Handle: {}'.format(handle))
+    click.echo('  Title: {}'.format(title))
+    click.echo('  Git repository: {}'.format(git_repo))
     click.confirm('Register this report?', abort=True)
 
     response = requests.post(

--- a/nbreport/cli/render.py
+++ b/nbreport/cli/render.py
@@ -1,0 +1,47 @@
+"""Implementation for the ``nbreport render`` command that renders a
+templated notebook instance.
+"""
+
+__all__ = ('render',)
+
+import click
+
+from ..instance import ReportInstance
+
+
+@click.command()
+@click.argument(
+    'instance_path', default=None, required=True, nargs=1,
+    type=click.Path(exists=True, file_okay=False, dir_okay=True)
+)
+@click.option(
+    '-c', '--config', 'template_variables', nargs=2, type=str, multiple=True,
+    help='Template key-value pairs. For example, if the report has a template '
+         'variable called ``cookiecutter.myvar``, you can provide it as '
+         '``-c myvar "Hello World!"``. You can provide multiple '
+         '-c/--config options.'
+)
+@click.pass_context
+def render(ctx, instance_path, template_variables):
+    """Render the notebook template of a newly-create instance.
+
+    Use this command to render the notebook template if you didn't provide
+    template variables with the ``nbreport init`` command.
+
+    **Required arguments**
+
+    ``INSTANCE_PATH``
+        The path to the report repository directory. You can create an
+        instance with the ``nbreport init`` command.
+    """
+    template_variables = dict(template_variables)
+    if len(template_variables) == 0:
+        # Set an empty dictionary to designate that we *are* rendering the
+        # template variables, but we're entirely using defaults from the
+        # cookiecutter.json file.
+        template_variables = {}
+
+    instance = ReportInstance(instance_path)
+    instance.render(context=template_variables)
+
+    click.echo('Rendered {0!s}'.format(instance.ipynb_path))

--- a/nbreport/cli/upload.py
+++ b/nbreport/cli/upload.py
@@ -25,11 +25,11 @@ def upload(ctx, instance_path):
         must already be computed with the ``nbreport compute`` command.
     """
     instance = ReportInstance(instance_path)
-    instance.upload(
+    queue_url = instance.upload(
         github_username=ctx.obj['config']['github']['username'],
         github_token=ctx.obj['config']['github']['token'],
         server=ctx.obj['server'])
 
-    click.echo('Upload complete.')
-    click.echo('Report is being published to {}'.format(
+    click.echo('Upload complete. Status: {}'.format(queue_url))
+    click.echo('Report is being published to\n\n{}'.format(
         instance.config['published_instance_url']))

--- a/nbreport/cli/upload.py
+++ b/nbreport/cli/upload.py
@@ -30,6 +30,7 @@ def upload(ctx, instance_path):
         github_token=ctx.obj['config']['github']['token'],
         server=ctx.obj['server'])
 
-    click.echo('Upload complete. Status: {}'.format(queue_url))
-    click.echo('Report is being published to\n\n{}'.format(
+    click.echo('Upload complete.')
+    click.echo('Processing status:\n  {}'.format(queue_url))
+    click.echo('Publication URL:\n  {}'.format(
         instance.config['published_instance_url']))

--- a/nbreport/compute.py
+++ b/nbreport/compute.py
@@ -93,7 +93,7 @@ def _run_preprocessor(preprocessor, notebook, dirname):
             'Error executing the notebook. See the notebook'
             '\n\n\t{output_path!s}\n\n'
             'for the traceback.'
-        )
+        ).format(output_path=output_path)
         logger.error(message)
         raise
 

--- a/nbreport/compute.py
+++ b/nbreport/compute.py
@@ -88,7 +88,7 @@ def _run_preprocessor(preprocessor, notebook, dirname):
     except CellExecutionError:
         uid = uuid.uuid4()
         output_path = Path('errored-{uid!s}.ipynb'.format(uid=uid)).resolve()
-        nbformat.write(notebook, output_path)
+        nbformat.write(notebook, str(output_path))
         message = (
             'Error executing the notebook. See the notebook'
             '\n\n\t{output_path!s}\n\n'

--- a/nbreport/instance.py
+++ b/nbreport/instance.py
@@ -225,7 +225,8 @@ class ReportInstance:
         response = requests.post(
             url,
             headers=headers,
-            data=nb_data
+            data=nb_data,
+            auth=(github_username, github_token)
         )
         response.raise_for_status()
 

--- a/nbreport/instance.py
+++ b/nbreport/instance.py
@@ -194,7 +194,10 @@ class ReportInstance:
         notebook = render_notebook(notebook, context, jinja_env)
 
         # Add config to the notebook metadata
-        notebook.metadata.update({'nbreport': dict(self.config)})
+        # Need to remove ruamel.yaml's special typing to be JSON-serializable
+        config_dict = dict(self.config)
+        config_dict['cookiecutter'] = dict(config_dict['cookiecutter'])
+        notebook.metadata.update({'nbreport': config_dict})
 
         nbformat.write(notebook, str(self.ipynb_path))
 

--- a/nbreport/instance.py
+++ b/nbreport/instance.py
@@ -83,7 +83,8 @@ class ReportInstance:
 
     @classmethod
     def from_report_repo(self, report_repo, instance_dirname, instance_id,
-                         context=None, overwrite=False):
+                         context=None, overwrite=False,
+                         published_instance_url=None, ltd_edition_url=None):
         """Create a new instance of a report from a report repository.
 
         This creates the instance directory on the filesystem and renders
@@ -108,6 +109,10 @@ class ReportInstance:
             If `True`, an existing report instance directory will be deleted
             and replaced by the new report instance directory. Default is
             `False`.
+        published_instance_url : `str`, optional
+            URL where the instance is published on LSST the Docs.
+        ltd_edition_url : `str`, optional
+            URL of the instance's edition resource in the LSST the Docs API.
 
         Returns
         -------
@@ -139,6 +144,8 @@ class ReportInstance:
         instance.config['instance_id'] = instance_id
         instance.config['instance_handle'] = '{handle}-{instance_id}'.format(
             **instance.config)
+        instance.config['published_instance_url'] = published_instance_url
+        instance.config['ltd_edition_url'] = ltd_edition_url
 
         if context is not None:
             instance.render(context=context)
@@ -208,6 +215,12 @@ class ReportInstance:
             this token.
         server : `str`
             URL of the nbreport API server.
+
+        Returns
+        -------
+        queue_url : `str`
+            URL to the nbreport API where you can obtain the status of a
+            report instance upload and publication.
         """
         url = urljoin(
             server,
@@ -231,6 +244,4 @@ class ReportInstance:
         response.raise_for_status()
 
         data = response.json()
-
-        self.config['published_instance_url'] = data['published_url']
-        self.config['ltd_edition_url'] = data['ltd_edition_url']
+        return data['queue_url']

--- a/nbreport/instance.py
+++ b/nbreport/instance.py
@@ -183,16 +183,13 @@ class ReportInstance:
                        'to the template context.')
                 self._logger.warning(msg)
 
-        print('extra_context')
-        print(context)
-
         context, jinja_env = load_template_environment(
             context_path=self.context_path,
             extra_context=context,
             system_context=system_context)
 
-        # Add context to the config
-        self.config.update({'context': context})
+        # Add the cookiecutter context to the config
+        self.config.update({'cookiecutter': context['cookiecutter']})
 
         notebook = render_notebook(notebook, context, jinja_env)
 

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -58,11 +58,11 @@ def test_init_command(write_user_config, testr_000_path, runner,
 
         # Check that the cookiecutter.json context got added to nbreport.yaml
         # This is just a sampling of the expected context
-        assert 'context' in instance.config
-        assert instance.config['context']['cookiecutter']['username'] \
+        assert 'cookiecutter' in instance.config
+        assert instance.config['cookiecutter']['username'] \
             == 'Test Bot'
-        assert instance.config['context']['cookiecutter']['a'] == '100'
-        assert instance.config['context']['cookiecutter']['b'] == '200'
+        assert instance.config['cookiecutter']['a'] == '100'
+        assert instance.config['cookiecutter']['b'] == '200'
 
         nb = instance.open_notebook()
 

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -19,7 +19,11 @@ def test_init_command(write_user_config, testr_000_path, runner,
     responses.add(
         responses.POST,
         'https://api.lsst.codes/nbreport/reports/testr-000/instances/',
-        json={'instance_id': '1'},
+        json={
+            'instance_id': '1',
+            'ltd_edition_url': 'https://keeper.lsst.codes/editions/12345',
+            'published_url': 'https://testr-000.lsst.io/v/1'
+        },
         status=201)
 
     with runner.isolated_filesystem():
@@ -84,7 +88,11 @@ def test_init_command_no_template_vars(
     responses.add(
         responses.POST,
         'https://api.lsst.codes/nbreport/reports/testr-000/instances/',
-        json={'instance_id': '1'},
+        json={
+            'instance_id': '1',
+            'ltd_edition_url': 'https://keeper.lsst.codes/editions/12345',
+            'published_url': 'https://testr-000.lsst.io/v/1'
+        },
         status=201)
 
     with runner.isolated_filesystem():

--- a/tests/test_cli_issue.py
+++ b/tests/test_cli_issue.py
@@ -19,15 +19,18 @@ def test_issue(write_user_config, testr_000_path, runner,
     responses.add(
         responses.POST,
         'https://api.lsst.codes/nbreport/reports/testr-000/instances/',
-        json={'instance_id': '1'},
+        json={
+            'instance_id': '1',
+            'ltd_edition_url': 'https://keeper.lsst.codes/editions/12345',
+            'published_url': 'https://testr-000.lsst.io/v/1'
+        },
         status=201)
     responses.add(
         responses.POST,
         'https://api.lsst.codes/nbreport/reports/testr-000/'
         'instances/1/notebook',
         json={
-            'ltd_edition_url': 'https://keeper.lsst.codes/editions/12345',
-            'published_url': 'https://testr-000.lsst.io/v/1'
+            'queue_url': 'https://example.com/queue/12345'
         },
         status=202)
 

--- a/tests/test_cli_upload.py
+++ b/tests/test_cli_upload.py
@@ -19,8 +19,7 @@ def test_upload(write_user_config, testr_000_path, runner, fake_registration):
         'https://api.lsst.codes/nbreport/reports/testr-000/'
         'instances/test/notebook',
         json={
-            'ltd_edition_url': 'https://keeper.lsst.codes/editions/12345',
-            'published_url': 'https://testr-000.lsst.io/v/test'
+            'queue_url': 'https://example.com/queue/12345'
         },
         status=202)
 
@@ -64,6 +63,3 @@ def test_upload(write_user_config, testr_000_path, runner, fake_registration):
         with open(instance.ipynb_path, 'rb') as fp:
             nbdata = fp.read()
             assert request.body == nbdata
-
-        assert instance.config['published_instance_url'] \
-            == 'https://testr-000.lsst.io/v/test'


### PR DESCRIPTION
This release fixes issues related to the integration of this ``nbreport`` command line client with the ``api.lsst.codes/nbreport`` backend microservice.

*New features:*

- Added the ``nbreport render`` command that renders the templated notebook of an iniitalized notebook instance that wasn't initially rendered (because no template variables were specified).

- Improved user messages from commands.

*Fixes:*

- Fixed bugs in ``nbreport.compute``.

- ``nbreport register`` now sends authentication data.

- The instance URL (``published_instance_url``) and API URL (``ltd_edition_url``) are now obtained during instance initialization.
  This matches when that data is readily available from teh ``api.lsst.codes/nbreport`` backend microservice.

- Replace ``context`` with ``cookiecutter`` in an instance's ``nbreport.yaml`` field.
  By only reporting data from the ``cookiecutter`` template context in ``nbreport.yaml``, we avoid duplicating information that's copied into the template context, like ``instance_id`` and ``handle``.

- More thoroughly cast config to JSON-serializable dict when inserting the ``nbreport.yaml`` instance metadata into the notebook's metadata.
  In ruamel.yaml 0.15.52 (2018-08-09), the CommentedMap type is no longer a subclass of OrderedDict.
  This meant that the configs were no longer JSON-serializable when directly inserted into notebook metadata.