### PR TITLE
DM-15430: Use prompts for username and password

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Change log
 ##########
 
+0.7.1 (2018-08-14)
+==================
+
+- For ``nbreport login``, now the user's GitHub username and password can *only* be provided through prompts.
+  Previously the password could be specified as a command-line option as well.
+
 0.7.0 (2018-08-12)
 ==================
 

--- a/nbreport/cli/login.py
+++ b/nbreport/cli/login.py
@@ -15,18 +15,8 @@ from ..userconfig import insert_github_config, write_config
 
 
 @click.command()
-@click.option(
-    '--name', 'github_username', prompt='Your GitHub username',
-    help='Your GitHub username. You’ll be prompted for it if not provided '
-         'as an option.'
-)
-@click.password_option(
-    '--password', 'github_password', prompt='Your GitHub password',
-    help='Your GitHub username. You’ll be prompted for it if not provided '
-         'as an option.'
-)
 @click.pass_context
-def login(ctx, github_username, github_password):
+def login(ctx):
     """Obtain a personal access token from GitHub.
 
     Other nbreport subcommands that publish report instances authenticate
@@ -42,7 +32,10 @@ def login(ctx, github_username, github_password):
     personal access token created by this command by going to
     https://github.com/settings/tokens.
     """
-    click.echo('Getting a personal access token from GitHub.')
+    github_username = click.prompt('Your GitHub username')
+    github_password = click.prompt('Your GitHub password', hide_input=True)
+
+    click.echo('Getting a personal access token from GitHub...')
 
     try:
         token_data = request_github_token(

--- a/tests/test_cli_login.py
+++ b/tests/test_cli_login.py
@@ -25,10 +25,11 @@ def test_login_command(runner):
         args = [
             '--config-file', 'nbreport.yaml',  # test-local config file
             'login',  # subcommand
-            '--name', 'testuser',
-            '--password', 'testpassword'
         ]
-        result = runner.invoke(nbreport.cli.main.main, args)
+        result = runner.invoke(
+            nbreport.cli.main.main,
+            args,
+            input='testuser\ntestpassword\n')
         assert result.exit_code == 0
 
         config_path = Path('nbreport.yaml')


### PR DESCRIPTION
Removes the option of providing the password as a command line argument as a security best practice.