### PR TITLE
Unpin the click dependency (0.7.4 release)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Change log
 ##########
 
+0.7.4 (2019-02-12)
+==================
+
+- The ``click`` dependency is now floating.
+  The click API used by nbreport is fairly stable, and unpinning improves compatibility with other package's in the user's environment.
+
 0.7.3 (2019-08-28)
 ==================
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ long_description = read('README.rst')
 
 # Core dependencies
 install_requires = [
-    'click>=6.7,<7.0',
+    'click',
     'cookiecutter>=1.6.0,<2.0.0',
     'nbformat',
     'nbconvert',
@@ -56,7 +56,7 @@ tests_require = [
 # Optional/development dependencies
 docs_require = [
     'documenteer[pipelines]>=0.5.0,<0.6.0',
-    'sphinx-click==2.2.0',
+    'sphinx-click',
 ]
 extras_require = {
     'dev': docs_require + tests_require


### PR DESCRIPTION
It turns out that pinning is not necessary as the API we're using is fairly stable.